### PR TITLE
Fix for macosx-version-min issue.

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -594,13 +594,13 @@ buildBoost_macOS()
 
     echo building Boost for macOS
     ./b2 $THREADS toolset=darwin-${MACOS_SDK_VERSION} --build-dir=macos-build --stagedir=macos-build/stage \
-        --prefix="$MACOS_OUTPUT_DIR/prefix" cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS}" architecture=x86 \
+        --prefix="$MACOS_OUTPUT_DIR/prefix" cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS}" architecture=x86 address-model=64 \
         linkflags="-stdlib=libc++" link=static threading=multi \
         macosx-version=${MACOS_SDK_VERSION} macosx-version-min=${MIN_MACOS_VERSION} stage >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
     if [ $? != 0 ]; then echo "Error staging macOS. Check log."; exit 1; fi
 
     ./b2 $THREADS toolset=darwin-${MACOS_SDK_VERSION} --build-dir=macos-build --stagedir=macos-build/stage \
-        --prefix="$MACOS_OUTPUT_DIR/prefix" cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS}" architecture=x86 \
+        --prefix="$MACOS_OUTPUT_DIR/prefix" cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS}" architecture=x86 address-model=64 \
         linkflags="-stdlib=libc++" link=static threading=multi \
         macosx-version=${MACOS_SDK_VERSION} macosx-version-min=${MIN_MACOS_VERSION} install >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
     if [ $? != 0 ]; then echo "Error installing macOS. Check log."; exit 1; fi

--- a/boost.sh
+++ b/boost.sh
@@ -185,8 +185,6 @@ OPTIONS:
 
     --min-macos-version [num]
         Specify the minimum macOS version to target.  Defaults to $MIN_MACOS_VERSION.
-        NOTE: It seems that this is ignored for some reason, even though it is
-        (I think) being correctly passed to the build system.
 
     --no-framework
         Do not create the framework.
@@ -595,17 +593,16 @@ buildBoost_macOS()
     mkdir -p $MACOS_OUTPUT_DIR
 
     echo building Boost for macOS
-    ./b2 $THREADS --build-dir=macos-build --stagedir=macos-build/stage toolset=clang \
-        --prefix="$MACOS_OUTPUT_DIR/prefix" cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS}" \
+    ./b2 $THREADS toolset=darwin-${MACOS_SDK_VERSION} --build-dir=macos-build --stagedir=macos-build/stage \
+        --prefix="$MACOS_OUTPUT_DIR/prefix" cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS}" architecture=x86 \
         linkflags="-stdlib=libc++" link=static threading=multi \
-        macosx-version=${MACOS_SDK_VERSION} stage >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
+        macosx-version=${MACOS_SDK_VERSION} macosx-version-min=${MIN_MACOS_VERSION} stage >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
     if [ $? != 0 ]; then echo "Error staging macOS. Check log."; exit 1; fi
 
-    ./b2 $THREADS --build-dir=macos-build --stagedir=macos-build/stage \
-        --prefix="$MACOS_OUTPUT_DIR/prefix" toolset=clang \
-        cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS}" \
+    ./b2 $THREADS toolset=darwin-${MACOS_SDK_VERSION} --build-dir=macos-build --stagedir=macos-build/stage \
+        --prefix="$MACOS_OUTPUT_DIR/prefix" cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS}" architecture=x86 \
         linkflags="-stdlib=libc++" link=static threading=multi \
-        macosx-version=${MACOS_SDK_VERSION} install >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
+        macosx-version=${MACOS_SDK_VERSION} macosx-version-min=${MIN_MACOS_VERSION} install >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
     if [ $? != 0 ]; then echo "Error installing macOS. Check log."; exit 1; fi
 
     doneSection


### PR DESCRIPTION
Proposed fix for issue: https://github.com/faithfracture/Apple-Boost-BuildScript/issues/5

I believe the main problem is that the b2 command was not passed an architecture parm (x86). This caused the user-config.jam settings to not be used at all. I debugged into it and none of the settings were being used: compiler path, compiler flags, etc. It was just using the defaults, which happened to work okay.

I made a few other tweaks of passing macosx-version-min into the b2 command, which I don't believe is required since it is also in the user-config.jam file, but it doesn't hurt to explicitly pass it in.

I also changed the toolset to darwin instead of clang. Before it needed to be clang because the darwin settings in user-config.jam weren't being used and using darwin would cause a compile error since the compiler path wasn't set (forcing the toolset to clang would result in a good compiler path). Now that the user-config.jam settings are being used (because architecture is specified for b2), we can be consistent and specify a toolset of darwin for macOS (just like iOs, tvOS, etc.).

I tested that the minimum OS SDK was properly being set via:

`otool -l libboost_thread.a  | grep -A 3 LC_VERSION_MIN_MACOSX`