### PR TITLE
Fixed macOS target problem that caused user-config.jam to be ignored, and fixed macOS specific  share_ptr crasher caused by using -DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS.

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -1004,7 +1004,7 @@ if [[ -z $BUILD_IOS && -z $BUILD_TVOS && -z $BUILD_MACOS ]]; then
 fi
 
 # Must set these after parseArgs to fill in overriden values
-EXTRA_FLAGS="-Wno-unused-local-typedef -fembed-bitcode"
+EXTRA_FLAGS="-fembed-bitcode -Wno-unused-local-typedef -Wno-nullability-completeness"
 
 # The EXTRA_ARM_FLAGS definition works around a thread race issue in
 # shared_ptr. I encountered this historically and have not verified that

--- a/boost.sh
+++ b/boost.sh
@@ -657,15 +657,15 @@ buildBoost_macOS()
     mkdir -p "$MACOS_OUTPUT_DIR"
 
     echo building Boost for macOS
-    ./b2 $THREADS --build-dir=macos-build --stagedir=macos-build/stage toolset=clang \
-        --prefix="$MACOS_OUTPUT_DIR/prefix" \
+    ./b2 $THREADS --build-dir=macos-build --stagedir=macos-build/stage --prefix="$MACOS_OUTPUT_DIR/prefix" \
+        toolset=darwin-${MACOS_SDK_VERSION} architecture=x86  \
         cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS} ${EXTRA_MACOS_SDK_FLAGS}" \
         linkflags="-stdlib=libc++ ${EXTRA_MACOS_SDK_FLAGS}" link=static threading=multi \
         macosx-version=${MACOS_SDK_VERSION} stage >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
     if [ $? != 0 ]; then echo "Error staging macOS. Check log."; exit 1; fi
 
-    ./b2 $THREADS --build-dir=macos-build --stagedir=macos-build/stage \
-        --prefix="$MACOS_OUTPUT_DIR/prefix" toolset=clang \
+    ./b2 $THREADS --build-dir=macos-build --stagedir=macos-build/stage --prefix="$MACOS_OUTPUT_DIR/prefix" \
+        toolset=darwin-${MACOS_SDK_VERSION} architecture=x86  \
         cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS} ${EXTRA_MACOS_SDK_FLAGS}" \
         linkflags="-stdlib=libc++ ${EXTRA_MACOS_SDK_FLAGS}" link=static threading=multi \
         macosx-version=${MACOS_SDK_VERSION} install >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
@@ -1000,20 +1000,25 @@ if [[ -z $BUILD_IOS && -z $BUILD_TVOS && -z $BUILD_MACOS ]]; then
     BUILD_MACOS=1
 fi
 
-# The EXTRA_FLAGS definition works around a thread race issue in
+# Must set these after parseArgs to fill in overriden values
+
+EXTRA_FLAGS="-fvisibility=hidden -fvisibility-inlines-hidden \
+    -Wno-unused-local-typedef -fembed-bitcode"
+
+# The EXTRA_ARM_FLAGS definition works around a thread race issue in
 # shared_ptr. I encountered this historically and have not verified that
 # the fix is no longer required. Without using the posix thread primitives
 # an invalid compare-and-swap ARM instruction (non-thread-safe) was used for the
 # shared_ptr use count causing nasty and subtle bugs.
 #
-# Should perhaps also consider/use instead: -BOOST_SP_USE_PTHREADS
+# Note these flags (BOOST_AC_USE_PTHREADS and BOOST_SP_USE_PTHREADS) should
+# only be defined for arm targets. They will cause random (but repeatable)
+# shared_ptr crashes on macOS in boost thread destructors.
 
-# Must set these after parseArgs to fill in overriden values
-EXTRA_FLAGS="-DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS -g -DNDEBUG \
-    -fvisibility=hidden -fvisibility-inlines-hidden \
-    -Wno-unused-local-typedef -fembed-bitcode"
-EXTRA_IOS_FLAGS="$EXTRA_FLAGS -mios-version-min=$MIN_IOS_VERSION"
-EXTRA_TVOS_FLAGS="$EXTRA_FLAGS -mtvos-version-min=$MIN_TVOS_VERSION"
+EXTRA_ARM_FLAGS="-DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS -g -DNDEBUG"
+
+EXTRA_IOS_FLAGS="$EXTRA_FLAGS $EXTRA_ARM_FLAGS -mios-version-min=$MIN_IOS_VERSION"
+EXTRA_TVOS_FLAGS="$EXTRA_FLAGS $EXTRA_ARM_FLAGS -mtvos-version-min=$MIN_TVOS_VERSION"
 EXTRA_MACOS_FLAGS="$EXTRA_FLAGS -mmacosx-version-min=$MIN_MACOS_VERSION"
 EXTRA_MACOS_SDK_FLAGS="-isysroot ${MACOS_SDK_PATH} -mmacosx-version-min=${MIN_MACOS_VERSION}"
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+-- 2018-09-20 --
+* Fixed macOS target problem that caused user-config.jam to be ignored
+* Fixed macOS specific share_ptr crasher caused by using -DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS
+
 -- 2018-06-07 --
 * Added a CLI flag to create universal FAT binaries for iOS and tvOS.
 


### PR DESCRIPTION
Although the pull request https://github.com/faithfracture/Apple-Boost-BuildScript/pull/22 fixed the macosx-version-min problem, it did not fix the underlying issue discussed and proposed by my https://github.com/faithfracture/Apple-Boost-BuildScript/pull/11 request. Rather than reopening that now pretty stale PR I created a new one.

The issue is that the user-config.jam is not being used at all for macOS target (just add some syntax errors to the macOS user-config.jam and you'll see it doesn't get used). This is because the toolset is set to **clang** instead of **darwin**. Additionally, **architecture=x86** needs to be passed into **b2**, then it will find/match and use the user-config.jam.

Once I got that working I ran into a crashing problem that occurs because of shared_ptr being deallocated twice inside of boost thread's destructor. The following code would consistently cause the crash, but will often taken thousands of iterations of the loop (creating and destroying threads) before it occurs:

```
static void do_nothing () { }

int main()
{
	int thread_count = 0;
	while (true) {
		thread_count++;
		boost::thread t1_thread(boost::bind(&do_nothing));
		if (t1_thread.joinable()) {
			t1_thread.join();
		}
	}
}
```
I noticed the crash only occurred with the libboost_thread created after the change above (meaning user-config.jam was used). I tracked this down to **EXTRA_MACOS_FLAGS** having these two flags set: **-DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS**. Before I fixed the user-config.jam problem **EXTRA_MACOS_FLAGS** wasn't being used at all (it is only specified in the .jam file, not the b2 call) which explains why the crash only started occurring after I fixed the .jam issue. My fix for this is to separate out those flags from **EXTRA_FLAGS** (used by all platforms) to **EXTRA_ARM_FLAGS** which is only used by the **arm** based targets. Based on the previous comment those flags were added only for the arm platform: "_Without using the posix thread primitives an invalid compare-and-swap ARM instruction (non-thread-safe) was used for the shared_ptr use count causing nasty and subtle bugs._" So the crash I was seeing (with code snippet above) isn't the exact same one as reported there – indeed it is the opposite in that it occurs when trying to use pthread_mutex_t for atomic count and shared_ptr locking. I'm not sure why pthread_mutex_t causes the crash on macOS, but empirically (based on code above) it consistently does. Removing **-DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS** and letting boost use platform specific locking by default avoids the crash, and shouldn't impact the original reason those flags were added since it was only intended for **arm** platform targets.

Here is a [bit more information](https://stackoverflow.com/questions/51438287/) where I tracked down the crasher.