### PR TITLE
Fix incorrect ordering of parameters for tar command

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -479,7 +479,7 @@ unpackBoost()
     echo Unpacking boost into "$SRCDIR"...
 
     [ -d "$SRCDIR" ]    || mkdir -p "$SRCDIR"
-    [ -d "$BOOST_SRC" ] || ( cd "$SRCDIR"; tar xfj "$BOOST_TARBALL" )
+    [ -d "$BOOST_SRC" ] || ( cd "$SRCDIR"; tar xjf "$BOOST_TARBALL" )
     [ -d "$BOOST_SRC" ] && echo "    ...unpacked as $BOOST_SRC"
 
     doneSection


### PR DESCRIPTION
The script was using
tar xfj "filename"
However, the syntax for tar is x no parameters f filename.  Filename may be either placed immediately after it or may be in the next parameter, with right after the priority.  So tar xfj is extract from file j.
Instead we want extract bzip2 file "filename", or tar xfj.
This is a trivial update changing just that problem.