### PR TITLE
Fix bugs where archs not copied over properly

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -451,11 +451,11 @@ parseArgs()
     fi
 
     if [[ -n $CUSTOM_MACOS_ARCHS ]]; then
-        IFS=' ' read -ra MACOS_ARCHS <<< "$CUSTOM_MACOS_ARCHS"
+        IFS=' ' read -ra MACOS_ARCHS <<< "${CUSTOM_MACOS_ARCHS[*]}"
     fi
 
     if [[ -n $CUSTOM_IOS_ARCHS ]]; then
-        IFS=' ' read -ra IOS_ARCHS <<< "$CUSTOM_IOS_ARCHS"
+        IFS=' ' read -ra IOS_ARCHS <<< "${CUSTOM_IOS_ARCHS[*]}"
         #IOS_ARCHS=($CUSTOM_IOS_ARCHS)
         IOS_SIM_ARCHS=()
         # As of right now this matches the currently available ARM architectures

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+-- 2019-09-20 --
+* Fixed incorrect architecture copying from CUSTOM_MACOS_ARCHS into MACOS_ARCHS (and similar for iOS)
+
 -- 2019-08-14 --
 * Fixed my being stupid, doing bash arrays wrong, and breaking everyone
 


### PR DESCRIPTION
If you defined your own macOS or iOS architectures (or used `--universal`), then the architectures were not copied correctly. This PR fixes that issue.

Before:
```
./boost.sh -macos --boost-version 1.70.0 --macos-sdk 10.14 --min-macos-version 10.10  --universal --boost-libs "chrono date_time filesystem system timer"
```
resulted in a `MACOS_ARCHS=i386`.

After the fix, `MACOS_ARCHS` has both `i386` and `x86_64`.
