### PR TITLE
Use bintray rather than sourceforge for downloads

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -507,12 +507,20 @@ cleanup()
 
 #===============================================================================
 
+# version() from https://stackoverflow.com/a/37939589/3938401
+version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; }
+
 downloadBoost()
 {
+         #   http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION2}.tar.bz2/download
+        if [ $(version $BOOST_VERSION) -ge $(version "1.63.0") ]; then
+            DOWNLOAD_SRC=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
+        else
+            DOWNLOAD_SRC=http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION2}.tar.bz2/download
+        fi
     if [ ! -s "$BOOST_TARBALL" ]; then
-        echo "Downloading boost ${BOOST_VERSION}"
-        curl -L -o "$BOOST_TARBALL" \
-            https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
+        echo "Downloading boost ${BOOST_VERSION} from ${DOWNLOAD_SRC}"
+        curl -L -o "$BOOST_TARBALL" "$DOWNLOAD_SRC"
         doneSection
     fi
 }

--- a/boost.sh
+++ b/boost.sh
@@ -512,12 +512,11 @@ version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; 
 
 downloadBoost()
 {
-         #   http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION2}.tar.bz2/download
-        if [ $(version $BOOST_VERSION) -ge $(version "1.63.0") ]; then
-            DOWNLOAD_SRC=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
-        else
-            DOWNLOAD_SRC=http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION2}.tar.bz2/download
-        fi
+    if [ $(version $BOOST_VERSION) -ge $(version "1.63.0") ]; then
+        DOWNLOAD_SRC=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
+    else
+        DOWNLOAD_SRC=http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION2}.tar.bz2/download
+    fi
     if [ ! -s "$BOOST_TARBALL" ]; then
         echo "Downloading boost ${BOOST_VERSION} from ${DOWNLOAD_SRC}"
         curl -L -o "$BOOST_TARBALL" "$DOWNLOAD_SRC"

--- a/boost.sh
+++ b/boost.sh
@@ -512,7 +512,7 @@ downloadBoost()
     if [ ! -s "$BOOST_TARBALL" ]; then
         echo "Downloading boost ${BOOST_VERSION}"
         curl -L -o "$BOOST_TARBALL" \
-            http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION2}.tar.bz2/download
+            https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
         doneSection
     fi
 }

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+-- 2019-09-20 --
+* Use bintray rather than sourceforge for downloads
+
 -- 2019-08-14 --
 * Fixed my being stupid, doing bash arrays wrong, and breaking everyone
 


### PR DESCRIPTION
For some reason, [sourceforge doesn't have boost 1.71.0 available](https://sourceforge.net/projects/boost/files/boost/1.71.0/). On the [official boost site](https://boost.org), `bintray` is used for downloads. This PR changes the URL used to download boost.