### PR TITLE
Fix shellcheck warnings and errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: shellcheck
+      uses: azohra/shell-linter@v0.2.0

--- a/boost.sh
+++ b/boost.sh
@@ -24,7 +24,7 @@
 #
 # If a boost tarball (a file named “boost_$BOOST_VERSION2.tar.bz2”) does not
 # exist in the current directory, this script will attempt to download the
-# version specified. You may also manually place a matching 
+# version specified. You may also manually place a matching
 # tarball in the current directory and the script will use that.
 #
 #===============================================================================
@@ -32,27 +32,27 @@
 BOOST_VERSION=1.69.0
 
 BOOST_LIBS="atomic chrono date_time exception filesystem program_options random system thread test"
-ALL_BOOST_LIBS_1_68=\
-"atomic chrono container context coroutine coroutine2 date_time exception fiber filesystem graph"\
-" graph_parallel iostreams locale log math metaparse mpi program_options python random regex"\
-" serialization signals system test thread timer type_erasure wave"
-ALL_BOOST_LIBS_1_69=\
-"atomic chrono container context coroutine coroutine2 date_time exception fiber filesystem graph"\
-" graph_parallel iostreams locale log math metaparse mpi program_options python random regex"\
-" serialization signals2 system test thread timer type_erasure wave"
+ALL_BOOST_LIBS_1_68="atomic chrono container context coroutine coroutine2
+date_time exception fiber filesystem graph graph_parallel iostreams locale log
+math metaparse mpi program_options python random regex serialization signals
+system test thread timer type_erasure wave"
+ALL_BOOST_LIBS_1_69="atomic chrono container context coroutine coroutine2
+date_time exception fiber filesystem graph graph_parallel iostreams locale log
+math metaparse mpi program_options python random regex serialization signals2
+system test thread timer type_erasure wave"
 BOOTSTRAP_LIBS=""
 
 MIN_IOS_VERSION=11.0
-IOS_SDK_VERSION=`xcrun --sdk iphoneos --show-sdk-version`
+IOS_SDK_VERSION=$(xcrun --sdk iphoneos --show-sdk-version)
 
 MIN_TVOS_VERSION=11.0
-TVOS_SDK_VERSION=`xcrun --sdk appletvos --show-sdk-version`
-TVOS_SDK_PATH=`xcrun --sdk appletvos --show-sdk-path`
-TVOSSIM_SDK_PATH=`xcrun --sdk appletvsimulator --show-sdk-path`
+TVOS_SDK_VERSION=$(xcrun --sdk appletvos --show-sdk-version)
+TVOS_SDK_PATH=$(xcrun --sdk appletvos --show-sdk-path)
+TVOSSIM_SDK_PATH=$(xcrun --sdk appletvsimulator --show-sdk-path)
 
 MIN_MACOS_VERSION=10.12
-MACOS_SDK_VERSION=`xcrun --sdk macosx --show-sdk-version`
-MACOS_SDK_PATH=`xcrun --sdk macosx --show-sdk-path`
+MACOS_SDK_VERSION=$(xcrun --sdk macosx --show-sdk-version)
+MACOS_SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
 
 MACOS_ARCHS=("x86_64")
 IOS_ARCHS=("armv7" "arm64")
@@ -61,12 +61,12 @@ IOS_SIM_ARCHS=("i386" "x86_64")
 # Applied to all platforms
 CXX_FLAGS="-std=c++14 -stdlib=libc++"
 
-XCODE_ROOT=`xcode-select -print-path`
-COMPILER="$XCODE_ROOT/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++" 
+XCODE_ROOT=$(xcode-select -print-path)
+COMPILER="$XCODE_ROOT/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++"
 
 THREADS="-j$(sysctl -n hw.ncpu)"
 
-CURRENT_DIR=`pwd`
+CURRENT_DIR=$(pwd)
 SRCDIR="$CURRENT_DIR/src"
 
 IOS_ARM_DEV_CMD="xcrun --sdk iphoneos"
@@ -85,7 +85,7 @@ usage()
 {
 cat << EOF
 usage: $0 [{-ios,-tvos,-macos} ...] options
-Build Boost for iOS, iOS Simulator, tvOS, tvOS Simulator, and macOS 
+Build Boost for iOS, iOS Simulator, tvOS, tvOS Simulator, and macOS
 The -ios, -tvos, and -macOS options may be specified together. Default
 is to build all of them.
 
@@ -165,7 +165,7 @@ OPTIONS:
 
         * math fails for iOS and tvOS with a complaint about using a PCH with
         multiple architectures defined. I don't know how to get around this if
-        you need a specific architecture (like arm64), since the only RISC 
+        you need a specific architecture (like arm64), since the only RISC
         option for the <architeciture> jamfile feature tag is 'arm'. I'm sure
         there's a way to get this working by tweaking user-config, but I haven't
         the time to figure it out now.
@@ -243,7 +243,7 @@ EOF
 abort()
 {
     echo
-    echo "Aborted: $@"
+    echo "Aborted:" "$@"
     exit 1
 }
 
@@ -253,21 +253,27 @@ die()
     exit 1
 }
 
+cd_or_abort()
+{
+    cd "$1" || abort "Could not change directory into \"$1\""
+}
+
 missingParameter()
 {
-    echo $1 requires a parameter
+    echo "$1 requires a parameter"
     die
 }
 
 unknownParameter()
 {
     if [[ -n $2 &&  $2 != "" ]]; then
-        echo Unknown argument \"$2\" for parameter $1.
+        echo "Unknown argument \"$2\" for parameter $1."
     else
-        echo Unknown argument $1
+        echo "Unknown argument $1"
     fi
     die
 }
+
 parseArgs()
 {
     while [ "$1" != "" ]; do
@@ -290,11 +296,11 @@ parseArgs()
                 ;;
 
             --boost-version)
-                if [ -n $2 ]; then
+                if [ -n "$2" ]; then
                     BOOST_VERSION=$2
                     shift
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
@@ -303,25 +309,25 @@ parseArgs()
                     CUSTOM_LIBS=$2
                     shift
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
             --ios-sdk)
-                if [ -n $2 ]; then
+                if [ -n "$2" ]; then
                     IOS_SDK_VERSION=$2
                     shift
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
             --min-ios-version)
-                if [ -n $2 ]; then
+                if [ -n "$2" ]; then
                     MIN_IOS_VERSION=$2
                     shift
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
@@ -330,43 +336,43 @@ parseArgs()
                     CUSTOM_IOS_ARCHS=$2
                     shift;
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
             --tvos-sdk)
-                if [ -n $2 ]; then
+                if [ -n "$2" ]; then
                     TVOS_SDK_VERSION=$2
                     shift
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
             --min-tvos-version)
-                if [ -n $2 ]; then
+                if [ -n "$2" ]; then
                     MIN_TVOS_VERSION=$2
                     shift
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
             --macos-sdk)
-                 if [ -n $2 ]; then
+                 if [ -n "$2" ]; then
                     MACOS_SDK_VERSION=$2
                     shift
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
             --min-macos-version)
-                if [ -n $2 ]; then
+                if [ -n "$2" ]; then
                     MIN_MACOS_VERSION=$2
                     shift
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
@@ -375,7 +381,7 @@ parseArgs()
                     CUSTOM_MACOS_ARCHS=$2
                     shift;
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
@@ -412,16 +418,16 @@ parseArgs()
                 ;;
 
             -j | --threads)
-                if [ -n $2 ]; then
+                if [ -n "$2" ]; then
                     THREADS="-j$2"
                     shift
                 else
-                    missingParameter $1
+                    missingParameter "$1"
                 fi
                 ;;
 
             *)
-                unknownParameter $1
+                unknownParameter "$1"
                 ;;
         esac
 
@@ -430,10 +436,10 @@ parseArgs()
 
     if [[ -n $CUSTOM_LIBS ]]; then
         if [[ "$CUSTOM_LIBS" == "none" ]]; then
-            CUSTOM_LIBS=
+            CUSTOM_LIBS=""
         elif [[ "$CUSTOM_LIBS" == "all" ]]; then
-            boostParts=(${BOOST_VERSION//\./ })
-            if [[ ${boostParts[1]} < 69 ]]; then
+            read -ra BOOST_PARTS <<< "${BOOST_VERSION//./ }"
+            if [[ ${BOOST_PARTS[1]} -lt 69 ]]; then
                 CUSTOM_LIBS=$ALL_BOOST_LIBS_1_68
             else
                 CUSTOM_LIBS=$ALL_BOOST_LIBS_1_69
@@ -450,26 +456,29 @@ parseArgs()
         CUSTOM_MACOS_ARCHS=("i386" "x86_64")
     fi
 
-    if [[ -n $CUSTOM_MACOS_ARCHS ]]; then
-        IFS=' ' read -ra MACOS_ARCHS <<< "$CUSTOM_MACOS_ARCHS"
+    if [[ "${#CUSTOM_MACOS_ARCHS[@]}" -gt 0 ]]; then
+        read -ra MACOS_ARCHS <<< "${CUSTOM_MACOS_ARCHS[@]}"
     fi
 
-    if [[ -n $CUSTOM_IOS_ARCHS ]]; then
-        IFS=' ' read -ra IOS_ARCHS <<< "$CUSTOM_IOS_ARCHS"
-        #IOS_ARCHS=($CUSTOM_IOS_ARCHS)
+    if [[ "${#CUSTOM_IOS_ARCHS[@]}" -gt 0 ]]; then
+        read -ra IOS_ARCHS <<< "${CUSTOM_IOS_ARCHS[@]}"
         IOS_SIM_ARCHS=()
         # As of right now this matches the currently available ARM architectures
         # Add 32-bit simulator for 32-bit arm
-        if [[ "${IOS_ARCHS[@]}" =~ armv ]]; then
+        if [[ "${IOS_ARCHS[*]}" =~ armv ]]; then
             IOS_SIM_ARCHS+=("i386")
         fi
         # Add 64-bit simulator for 64-bit arm
-        if [[ "${IOS_ARCHS[@]}" =~ arm64 ]]; then
+        if [[ "${IOS_ARCHS[*]}" =~ arm64 ]]; then
             IOS_SIM_ARCHS+=("x86_64")
         fi
-    elif (( $(echo "$MIN_IOS_VERSION >= 11.0" | bc -l) )); then
-        IOS_ARCHS=("arm64")
-        IOS_SIM_ARCHS=("x86_64")
+    else
+        read -ra MIN_IOS_PARTS <<< "${MIN_IOS_VERSION//./ }"
+        if [[ ${MIN_IOS_PARTS[0]} -ge 11 ]]; then
+            # iOS 11 dropped support for 32bit devices
+            IOS_ARCHS=("arm64")
+            IOS_SIM_ARCHS=("x86_64")
+        fi
     fi
 }
 
@@ -512,7 +521,7 @@ version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; 
 
 downloadBoost()
 {
-    if [ $(version $BOOST_VERSION) -ge $(version "1.63.0") ]; then
+    if [ "$(version "$BOOST_VERSION")" -ge "$(version "1.63.0")" ]; then
         DOWNLOAD_SRC=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
     else
         DOWNLOAD_SRC=http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION2}.tar.bz2/download
@@ -533,7 +542,7 @@ unpackBoost()
     echo Unpacking boost into "$SRCDIR"...
 
     [ -d "$SRCDIR" ]    || mkdir -p "$SRCDIR"
-    [ -d "$BOOST_SRC" ] || ( cd "$SRCDIR"; tar xjf "$BOOST_TARBALL" )
+    [ -d "$BOOST_SRC" ] || ( cd_or_abort "$SRCDIR"; tar xjf "$BOOST_TARBALL" )
     [ -d "$BOOST_SRC" ] && echo "    ...unpacked as $BOOST_SRC"
 
     doneSection
@@ -555,7 +564,7 @@ inventMissingHeaders()
 
 updateBoost()
 {
-    echo Updating boost into $BOOST_SRC...
+    echo "Updating boost into $BOOST_SRC..."
 
     USING_MPI=
     if [[ $BOOST_LIBS == *"mpi"* ]]; then
@@ -612,35 +621,35 @@ EOF
 
 bootstrapBoost()
 {
-    cd "$BOOST_SRC"
+    cd_or_abort "$BOOST_SRC"
     if [[ -z $BOOST_LIBS ]]; then
-        ./bootstrap.sh --without-libraries=${ALL_BOOST_LIBS// /,}
+        ./bootstrap.sh --without-libraries="${ALL_BOOST_LIBS// /,}"
     else
         BOOTSTRAP_LIBS=$BOOST_LIBS
         # Strip out unsupported / unavailable libraries
         if [[ "$1" == "iOS" ]]; then
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/context//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/coroutine//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/coroutine2//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/math//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/mpi//')
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//context/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//coroutine/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//coroutine2/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//math/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//mpi/}"
         fi
 
         if [[ "$1" == "tvOS" ]]; then
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/container//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/context//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/coroutine//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/coroutine2//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/math//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/metaparse//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/mpi//')
-            BOOTSTRAP_LIBS=$(echo $BOOTSTRAP_LIBS | sed -e 's/test//')
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//container/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//context/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//coroutine/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//coroutine2/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//math/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//metaparse/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//mpi/}"
+            BOOTSTRAP_LIBS="${BOOTSTRAP_LIBS//test/}"
         fi
 
         echo "Bootstrap libs ${BOOTSTRAP_LIBS}"
-        BOOST_LIBS_COMMA=$(echo $BOOTSTRAP_LIBS | sed -e 's/[[:space:]]/,/g')
+        BOOST_LIBS_COMMA="${BOOTSTRAP_LIBS// /,}"
         echo "Bootstrapping for $1 (with libs $BOOST_LIBS_COMMA)"
-        ./bootstrap.sh --with-libraries=$BOOST_LIBS_COMMA
+        ./bootstrap.sh --with-libraries="$BOOST_LIBS_COMMA"
     fi
 
     doneSection
@@ -650,82 +659,90 @@ bootstrapBoost()
 
 buildBoost_iOS()
 {
-    cd "$BOOST_SRC"
+    cd_or_abort "$BOOST_SRC"
     mkdir -p "$IOS_OUTPUT_DIR"
 
     echo Building Boost for iPhone
     # Install this one so we can copy the headers for the frameworks...
-    ./b2 $THREADS --build-dir=iphone-build --stagedir=iphone-build/stage \
+    ./b2 "$THREADS" --build-dir=iphone-build --stagedir=iphone-build/stage \
         --prefix="$IOS_OUTPUT_DIR/prefix" toolset=darwin \
         cxxflags="${CXX_FLAGS} ${IOS_ARCH_FLAGS[*]}" architecture=arm target-os=iphone linkflags="-stdlib=libc++" \
-        macosx-version=iphone-${IOS_SDK_VERSION} define=_LITTLE_ENDIAN \
+        macosx-version="iphone-$IOS_SDK_VERSION" define=_LITTLE_ENDIAN \
         link=static variant=${BUILD_VARIANT} stage >> "${IOS_OUTPUT_DIR}/ios-build.log" 2>&1
+    # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging iPhone. Check log."; exit 1; fi
 
-    ./b2 $THREADS --build-dir=iphone-build --stagedir=iphone-build/stage \
+    ./b2 "$THREADS" --build-dir=iphone-build --stagedir=iphone-build/stage \
         --prefix="$IOS_OUTPUT_DIR/prefix" toolset=darwin \
         cxxflags="${CXX_FLAGS} ${IOS_ARCH_FLAGS[*]}" architecture=arm linkflags="-stdlib=libc++" \
-        target-os=iphone macosx-version=iphone-${IOS_SDK_VERSION} \
+        target-os=iphone macosx-version="iphone-$IOS_SDK_VERSION" \
         define=_LITTLE_ENDIAN link=static variant=${BUILD_VARIANT} install >> "${IOS_OUTPUT_DIR}/ios-build.log" 2>&1
+    # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error installing iPhone. Check log."; exit 1; fi
     doneSection
 
     echo Building Boost for iPhoneSimulator
-    ./b2 $THREADS --build-dir=iphonesim-build --stagedir=iphonesim-build/stage \
-        toolset=darwin-${IOS_SDK_VERSION}~iphonesim \
+    ./b2 "$THREADS" --build-dir=iphonesim-build --stagedir=iphonesim-build/stage \
+        toolset="darwin-{IOS_SDK_VERSION}~iphonesim" \
         cxxflags="${CXX_FLAGS} ${IOS_SIM_ARCH_FLAGS[*]}" architecture=x86 linkflags="-stdlib=libc++" \
-        target-os=iphone macosx-version=iphonesim-${IOS_SDK_VERSION} \
+        target-os=iphone macosx-version="iphonesim-$IOS_SDK_VERSION" \
         link=static variant=${BUILD_VARIANT} stage >> "${IOS_OUTPUT_DIR}/ios-build.log" 2>&1
+    # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging iPhoneSimulator. Check log."; exit 1; fi
     doneSection
 }
 
 buildBoost_tvOS()
 {
-    cd "$BOOST_SRC"
+    cd_or_abort "$BOOST_SRC"
     mkdir -p "$TVOS_OUTPUT_DIR"
 
     echo Building Boost for AppleTV
-    ./b2 $THREADS --build-dir=appletv-build --stagedir=appletv-build/stage \
-        --prefix="$TVOS_OUTPUT_DIR/prefix" toolset=darwin-${TVOS_SDK_VERSION}~appletv \
+    ./b2 "$THREADS" --build-dir=appletv-build --stagedir=appletv-build/stage \
+        --prefix="$TVOS_OUTPUT_DIR/prefix" toolset="darwin-$TVOS_SDK_VERSION~appletv" \
         cxxflags="${CXX_FLAGS}" architecture=arm target-os=iphone define=_LITTLE_ENDIAN linkflags="-stdlib=libc++" \
         link=static variant=${BUILD_VARIANT} stage >> "${TVOS_OUTPUT_DIR}/tvos-build.log" 2>&1
+    # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging AppleTV. Check log."; exit 1; fi
 
-    ./b2 $THREADS --build-dir=appletv-build --stagedir=appletv-build/stage \
-        --prefix="$TVOS_OUTPUT_DIR/prefix" toolset=darwin-${TVOS_SDK_VERSION}~appletv \
+    ./b2 "$THREADS" --build-dir=appletv-build --stagedir=appletv-build/stage \
+        --prefix="$TVOS_OUTPUT_DIR/prefix" toolset="darwin-$TVOS_SDK_VERSION~appletv" \
         cxxflags="${CXX_FLAGS}" architecture=arm target-os=iphone define=_LITTLE_ENDIAN linkflags="-stdlib=libc++" \
         link=static variant=${BUILD_VARIANT} install >> "${TVOS_OUTPUT_DIR}/tvos-build.log" 2>&1
+    # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error installing AppleTV. Check log."; exit 1; fi
     doneSection
 
     echo Building Boost for AppleTVSimulator
-    ./b2 $THREADS --build-dir=appletv-build --stagedir=appletvsim-build/stage \
-        toolset=darwin-${TVOS_SDK_VERSION}~appletvsim architecture=x86 \
+    ./b2 "$THREADS" --build-dir=appletv-build --stagedir=appletvsim-build/stage \
+        toolset="darwin-$TVOS_SDK_VERSION~appletvsim" architecture=x86 \
         cxxflags="${CXX_FLAGS}" target-os=iphone link=static variant=${BUILD_VARIANT} linkflags="-stdlib=libc++" \
         stage >> "${TVOS_OUTPUT_DIR}/tvos-build.log" 2>&1
+    # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging AppleTVSimulator. Check log."; exit 1; fi
     doneSection
 }
 
 buildBoost_macOS()
 {
-    cd "$BOOST_SRC"
+    cd_or_abort "$BOOST_SRC"
     mkdir -p "$MACOS_OUTPUT_DIR"
 
     echo building Boost for macOS
-    ./b2 $THREADS --build-dir=macos-build --stagedir=macos-build/stage --prefix="$MACOS_OUTPUT_DIR/prefix" \
-        toolset=darwin-${MACOS_SDK_VERSION} architecture=x86  \
+    ./b2 "$THREADS" --build-dir=macos-build --stagedir=macos-build/stage --prefix="$MACOS_OUTPUT_DIR/prefix" \
+        toolset="darwin-$MACOS_SDK_VERSION" architecture=x86  \
         cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS[*]} ${EXTRA_MACOS_SDK_FLAGS}" \
         linkflags="-stdlib=libc++ ${EXTRA_MACOS_SDK_FLAGS}" link=static variant=${BUILD_VARIANT} threading=multi \
-        macosx-version=${MACOS_SDK_VERSION} stage >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
+        macosx-version="${MACOS_SDK_VERSION}" stage >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
+    # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging macOS. Check log."; exit 1; fi
 
-    ./b2 $THREADS --build-dir=macos-build --stagedir=macos-build/stage --prefix="$MACOS_OUTPUT_DIR/prefix" \
-        toolset=darwin-${MACOS_SDK_VERSION} architecture=x86  \
+    ./b2 "$THREADS" --build-dir=macos-build --stagedir=macos-build/stage --prefix="$MACOS_OUTPUT_DIR/prefix" \
+        toolset="darwin-$MACOS_SDK_VERSION" architecture=x86  \
         cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS[*]} ${EXTRA_MACOS_SDK_FLAGS}" \
         linkflags="-stdlib=libc++ ${EXTRA_MACOS_SDK_FLAGS}" link=static variant=${BUILD_VARIANT} threading=multi \
-        macosx-version=${MACOS_SDK_VERSION} install >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
+        macosx-version="$MACOS_SDK_VERSION" install >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
+    # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error installing macOS. Check log."; exit 1; fi
 
     doneSection
@@ -740,16 +757,16 @@ unpackArchive()
 
     echo "Unpacking $BUILDDIR/$LIBNAME"
 
-    if [[ -d "$BUILDDIR/$LIBNAME" ]]; then 
-        cd "$BUILDDIR/$LIBNAME"
-        rm *.o
-        rm *.SYMDEF*
+    if [[ -d "$BUILDDIR/$LIBNAME" ]]; then
+        cd_or_abort "$BUILDDIR/$LIBNAME"
+        rm ./*.o
+        rm ./*.SYMDEF*
     else
         mkdir -p "$BUILDDIR/$LIBNAME"
     fi
 
     (
-        cd "$BUILDDIR/$NAME"; ar -x "../../libboost_$NAME.a";
+        cd_or_abort "$BUILDDIR/$NAME"; ar -x "../../libboost_$NAME.a";
         for FILE in *.o; do
             NEW_FILE="${NAME}_${FILE}"
             mv "$FILE" "$NEW_FILE"
@@ -759,16 +776,16 @@ unpackArchive()
 
 scrunchAllLibsTogetherInOneLibPerPlatform()
 {
-    cd "$BOOST_SRC"
+    cd_or_abort "$BOOST_SRC"
 
     if [[ -n $BUILD_IOS ]]; then
         # iOS Device
-        for ARCH in ${IOS_ARCHS[@]}; do
+        for ARCH in "${IOS_ARCHS[@]}"; do
             mkdir -p "$IOS_BUILD_DIR/$ARCH/obj"
         done
 
         # iOS Simulator
-        for ARCH in ${IOS_SIM_ARCHS[@]}; do
+        for ARCH in "${IOS_SIM_ARCHS[@]}"; do
             mkdir -p "$IOS_BUILD_DIR/$ARCH/obj"
         done
     fi
@@ -783,7 +800,7 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
 
     if [[ -n $BUILD_MACOS ]]; then
         # macOS
-        for ARCH in ${MACOS_ARCHS[@]}; do
+        for ARCH in "${MACOS_ARCHS[@]}"; do
             mkdir -p "$MACOS_BUILD_DIR/$ARCH/obj"
         done
     fi
@@ -800,20 +817,20 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
         ALL_LIBS="$ALL_LIBS libboost_$NAME.a"
 
         if [[ -n $BUILD_IOS ]]; then
-            if [[ ${#IOS_ARCHS[@]} > 1 ]]; then
-                for ARCH in ${IOS_ARCHS[@]}; do
+            if [[ "${#IOS_ARCHS[@]}" -gt 1 ]]; then
+                for ARCH in "${IOS_ARCHS[@]}"; do
                     $IOS_ARM_DEV_CMD lipo "iphone-build/stage/lib/libboost_$NAME.a" \
-                        -thin $ARCH -o "$IOS_BUILD_DIR/$ARCH/libboost_$NAME.a"
+                        -thin "$ARCH" -o "$IOS_BUILD_DIR/$ARCH/libboost_$NAME.a"
                 done
             else
                 cp "iphone-build/stage/lib/libboost_$NAME.a" \
                     "$IOS_BUILD_DIR/${IOS_ARCHS[0]}/libboost_$NAME.a"
             fi
 
-            if [[ ${#IOS_SIM_ARCHS[@]} > 1 ]]; then
-                for ARCH in ${IOS_SIM_ARCHS[@]}; do
+            if [[ "${#IOS_SIM_ARCHS[@]}" -gt 1 ]]; then
+                for ARCH in "${IOS_SIM_ARCHS[@]}"; do
                     $IOS_SIM_DEV_CMD lipo "iphonesim-build/stage/lib/libboost_$NAME.a" \
-                        -thin $ARCH -o "$IOS_BUILD_DIR/$ARCH/libboost_$NAME.a"
+                        -thin "$ARCH" -o "$IOS_BUILD_DIR/$ARCH/libboost_$NAME.a"
                 done
             else
                 cp "iphonesim-build/stage/lib/libboost_$NAME.a" \
@@ -830,10 +847,10 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
         fi
 
         if [[ -n $BUILD_MACOS ]]; then
-            if (( ${#MACOS_ARCHS[@]} > 1 )); then
-                for ARCH in ${MACOS_ARCHS[@]}; do
+            if [[ "${#MACOS_ARCHS[@]}" -gt 1 ]]; then
+                for ARCH in "${MACOS_ARCHS[@]}"; do
                     $MACOS_DEV_CMD lipo "macos-build/stage/lib/libboost_$NAME.a" \
-                        -thin $ARCH -o "$MACOS_BUILD_DIR/$ARCH/libboost_$NAME.a"
+                        -thin "$ARCH" -o "$MACOS_BUILD_DIR/$ARCH/libboost_$NAME.a"
                 done
             else
                 cp "macos-build/stage/lib/libboost_$NAME.a" \
@@ -851,10 +868,10 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
 
         echo "Decomposing libboost_${NAME}.a"
         if [[ -n $BUILD_IOS ]]; then
-            for ARCH in ${IOS_ARCHS[@]}; do
+            for ARCH in "${IOS_ARCHS[@]}"; do
                 unpackArchive "$IOS_BUILD_DIR/$ARCH/obj" $NAME
             done
-            for ARCH in ${IOS_SIM_ARCHS[@]}; do
+            for ARCH in "${IOS_SIM_ARCHS[@]}"; do
                 unpackArchive "$IOS_BUILD_DIR/$ARCH/obj" $NAME
             done
         fi
@@ -865,7 +882,7 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
         fi
 
         if [[ -n $BUILD_MACOS ]]; then
-            for ARCH in ${MACOS_ARCHS[@]}; do
+            for ARCH in "${MACOS_ARCHS[@]}"; do
                 unpackArchive "$MACOS_BUILD_DIR/$ARCH/obj" $NAME
             done
         fi
@@ -873,16 +890,15 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
 
     echo "Linking each architecture into an uberlib ($ALL_LIBS => libboost.a )"
     if [[ -n $BUILD_IOS ]]; then
-        for ARCH in ${IOS_ARCHS[@]}; do
+        for ARCH in "${IOS_ARCHS[@]}"; do
             rm "$IOS_BUILD_DIR/$ARCH/libboost.a"
         done
     fi
     if [[ -n $BUILD_TVOS ]]; then
-        cd "$TVOS_BUILD_DIR"
-        rm */libboost.a
+        rm "$TVOS_BUILD_DIR"/*/libboost.a
     fi
     if [[ -n $BUILD_MACOS ]]; then
-        for ARCH in ${MACOS_ARCHS[@]}; do
+        for ARCH in "${MACOS_ARCHS[@]}"; do
             rm "$MACOS_BUILD_DIR/$ARCH/libboost.a"
         done
     fi
@@ -898,28 +914,28 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
         # Boost lib names probably won't contain non-word characters any time soon, though. ;) - Jan
 
         if [[ -n $BUILD_IOS ]]; then
-            for ARCH in ${IOS_ARCHS[@]}; do
-                echo ...ios-$ARCH
-                (cd "$IOS_BUILD_DIR/$ARCH"; $IOS_ARM_DEV_CMD ar crus libboost.a obj/$NAME/*.o; )
+            for ARCH in "${IOS_ARCHS[@]}"; do
+                echo "...ios-$ARCH"
+                (cd_or_abort "$IOS_BUILD_DIR/$ARCH"; $IOS_ARM_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
             done
 
-            for ARCH in ${IOS_SIM_ARCHS[@]}; do
-                echo ...ios-sim-$ARCH
-                (cd "$IOS_BUILD_DIR/$ARCH"; $IOS_SIM_ARM_DEV_CMD ar crus libboost.a obj/$NAME/*.o; )
+            for ARCH in "${IOS_SIM_ARCHS[@]}"; do
+                echo "...ios-sim-$ARCH"
+                (cd_or_abort "$IOS_BUILD_DIR/$ARCH"; $IOS_SIM_ARM_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
             done
         fi
 
         if [[ -n $BUILD_TVOS ]]; then
-            echo ...tvOS-arm64
-            (cd "$TVOS_BUILD_DIR/arm64"; $TVOS_ARM_DEV_CMD ar crus libboost.a obj/$NAME/*.o; )
-            echo ...tvOS-x86_64
-            (cd "$TVOS_BUILD_DIR/x86_64";  $TVOS_SIM_DEV_CMD ar crus libboost.a obj/$NAME/*.o; )
+            echo "...tvOS-arm64"
+            (cd_or_abort "$TVOS_BUILD_DIR/arm64"; $TVOS_ARM_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
+            echo "...tvOS-x86_64"
+            (cd_or_abort "$TVOS_BUILD_DIR/x86_64";  $TVOS_SIM_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
         fi
 
         if [[ -n $BUILD_MACOS ]]; then
-            for ARCH in ${MACOS_ARCHS[@]}; do
-                echo ...macos-$ARCH
-                (cd "$MACOS_BUILD_DIR/$ARCH";  $MACOS_DEV_CMD ar crus libboost.a obj/$NAME/*.o; )
+            for ARCH in "${MACOS_ARCHS[@]}"; do
+                echo "...macos-$ARCH"
+                (cd_or_abort "$MACOS_BUILD_DIR/$ARCH";  $MACOS_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
             done
         fi
     done
@@ -927,67 +943,67 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
 
 buildUniversal()
 {
-        echo "Creating universal library..."
+    echo "Creating universal library..."
     if [[ -n $BUILD_IOS ]]; then
         mkdir -p "$IOS_BUILD_DIR/universal"
 
-        cd "$IOS_BUILD_DIR"
+        cd_or_abort "$IOS_BUILD_DIR"
         for NAME in $BOOTSTRAP_LIBS; do
             if [ "$NAME" == "test" ]; then
                 NAME="unit_test_framework"
             fi
 
-            ARCH_FILES=""
-            for ARCH in ${IOS_ARCHS[@]}; do
-                ARCH_FILES+=" $ARCH/libboost_$NAME.a"
+            ARCH_FILES=()
+            for ARCH in "${IOS_ARCHS[@]}"; do
+                ARCH_FILES+=("$ARCH/libboost_$NAME.a")
             done
-            for ARCH in ${IOS_SIM_ARCHS[@]}; do
-                ARCH_FILES+=" $ARCH/libboost_$NAME.a"
+            for ARCH in "${IOS_SIM_ARCHS[@]}"; do
+                ARCH_FILES+=("$ARCH/libboost_$NAME.a")
             done
-            if [[ ${ARCH_FILES[@]} ]]; then
+            if [[ "${#ARCH_FILES[@]}" -gt 0 ]]; then
                 echo "... $NAME"
-                $IOS_ARM_DEV_CMD lipo -create $ARCH_FILES -o "universal/libboost_$NAME.a" || abort "Lipo $1 failed"
+                $IOS_ARM_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
             fi
         done
     fi
     if [[ -n $BUILD_TVOS ]]; then
         mkdir -p "$TVOS_BUILD_DIR/universal"
 
-        cd "$TVOS_BUILD_DIR"
+        cd_or_abort "$TVOS_BUILD_DIR"
         for NAME in $BOOTSTRAP_LIBS; do
             if [ "$NAME" == "test" ]; then
                 NAME="unit_test_framework"
             fi
 
-            ARCH_FILES=""
+            ARCH_FILES=()
             if [ -f "arm64/libboost_$NAME.a" ]; then
-                ARCH_FILES+=" arm64/libboost_$NAME.a"
+                ARCH_FILES+=("arm64/libboost_$NAME.a")
             fi
             if [ -f "x86_64/libboost_$NAME.a" ]; then
-                ARCH_FILES+=" x86_64/libboost_$NAME.a"
+                ARCH_FILES+=("x86_64/libboost_$NAME.a")
             fi
-            if [[ ${ARCH_FILES[@]} ]]; then
+            if [[ "${#ARCH_FILES[@]}" -gt 0 ]]; then
                 echo "... $NAME"
-                $TVOS_ARM_DEV_CMD lipo -create $ARCH_FILES -o "universal/libboost_$NAME.a" || abort "Lipo $1 failed"
+                $TVOS_ARM_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
             fi
         done
     fi
     if [[ -n $BUILD_MACOS ]]; then
         mkdir -p "$MACOS_BUILD_DIR/universal"
 
-        cd "$MACOS_BUILD_DIR"
+        cd_or_abort "$MACOS_BUILD_DIR"
         for NAME in $BOOTSTRAP_LIBS; do
             if [ "$NAME" == "test" ]; then
                 NAME="unit_test_framework"
             fi
 
-            ARCH_FILES=""
-            for ARCH in ${MACOS_ARCHS[@]}; do
-                ARCH_FILES+=" $ARCH/libboost_$NAME.a"
+            ARCH_FILES=()
+            for ARCH in "${MACOS_ARCHS[@]}"; do
+                ARCH_FILES+=("$ARCH/libboost_$NAME.a")
             done
-            if [[ ${ARCH_FILES[@]} ]]; then
+            if [[ "${#ARCH_FILES[@]}" -gt 0 ]]; then
                 echo "... $NAME"
-                $TVOS_ARM_DEV_CMD lipo -create $ARCH_FILES -o "universal/libboost_$NAME.a" || abort "Lipo $1 failed"
+                $TVOS_ARM_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
             fi
         done
     fi
@@ -996,17 +1012,15 @@ buildUniversal()
 #===============================================================================
 buildFramework()
 {
-    : ${1:?}
+    : "${1:?}"
     FRAMEWORKDIR="$1"
     BUILDDIR="$2/build"
     PREFIXDIR="$2/prefix"
 
-    VERSION_TYPE=Alpha
     FRAMEWORK_NAME=boost
     FRAMEWORK_VERSION=A
 
     FRAMEWORK_CURRENT_VERSION="$BOOST_VERSION"
-    FRAMEWORK_COMPATIBILITY_VERSION="$BOOST_VERSION"
 
     FRAMEWORK_BUNDLE="$FRAMEWORKDIR/$FRAMEWORK_NAME.framework"
     echo "Framework: Building $FRAMEWORK_BUNDLE from $BUILDDIR..."
@@ -1034,15 +1048,15 @@ buildFramework()
 
     if [[ -n $BOOTSTRAP_LIBS ]]; then
         echo "Lipoing library into $FRAMEWORK_INSTALL_NAME..."
-        cd "$BUILDDIR"
+        cd_or_abort "$BUILDDIR"
         if [[ -n $BUILD_IOS ]]; then
-            $IOS_ARM_DEV_CMD lipo -create */libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
+            $IOS_ARM_DEV_CMD lipo -create ./*/libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
         fi
         if [[ -n $BUILD_TVOS ]]; then
-            $TVOS_ARM_DEV_CMD lipo -create */libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
+            $TVOS_ARM_DEV_CMD lipo -create ./*/libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
         fi
         if [[ -n $BUILD_MACOS ]]; then
-            $MACOS_DEV_CMD lipo -create */libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
+            $MACOS_DEV_CMD lipo -create ./*/libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
         fi
     fi
 
@@ -1117,52 +1131,58 @@ MACOS_OUTPUT_DIR="$OUTPUT_DIR/macos/$BUILD_VARIANT"
 IOS_BUILD_DIR="$IOS_OUTPUT_DIR/build"
 TVOS_BUILD_DIR="$TVOS_OUTPUT_DIR/build"
 MACOS_BUILD_DIR="$MACOS_OUTPUT_DIR/build"
-IOSLOG="> $IOS_OUTPUT_DIR/iphone.log 2>&1"
 IOS_FRAMEWORK_DIR="$IOS_OUTPUT_DIR/framework"
 TVOS_FRAMEWORK_DIR="$TVOS_OUTPUT_DIR/framework"
 MACOS_FRAMEWORK_DIR="$MACOS_OUTPUT_DIR/framework"
 
 MACOS_ARCH_FLAGS=()
-for ARCH in ${MACOS_ARCHS[@]}; do
+for ARCH in "${MACOS_ARCHS[@]}"; do
     MACOS_ARCH_FLAGS+=("-arch $ARCH")
 done
 
 IOS_ARCH_FLAGS=()
-for ARCH in ${IOS_ARCHS[@]}; do
+for ARCH in "${IOS_ARCHS[@]}"; do
     IOS_ARCH_FLAGS+=("-arch $ARCH")
 done
 
 IOS_SIM_ARCH_FLAGS=()
-for ARCH in ${IOS_SIM_ARCHS[@]}; do
+for ARCH in "${IOS_SIM_ARCHS[@]}"; do
     IOS_SIM_ARCH_FLAGS+=("-arch $ARCH")
 done
 
-format="%-20s %s\n"
-printf "$format" "BUILD_IOS:" $( [[ -n $BUILD_IOS ]] && echo "YES" || echo "NO")
-printf "$format" "BUILD_TVOS:" $( [[ -n $BUILD_TVOS ]] && echo "YES" || echo "NO")
-printf "$format" "BUILD_MACOS:" $( [[ -n $BUILD_MACOS ]] && echo "YES" || echo "NO")
-printf "$format" "BOOST_VERSION:" "$BOOST_VERSION"
-printf "$format" "IOS_SDK_VERSION:" "$IOS_SDK_VERSION"
-printf "$format" "MIN_IOS_VERSION:" "$MIN_IOS_VERSION"
-printf "$format" "TVOS_SDK_VERSION:" "$TVOS_SDK_VERSION"
-printf "$format" "TVOS_SDK_PATH:" "$TVOS_SDK_PATH"
-printf "$format" "TVOSSIM_SDK_PATH:" "$TVOSSIM_SDK_PATH"
-printf "$format" "MIN_TVOS_VERSION:" "$MIN_TVOS_VERSION"
-printf "$format" "MACOS_SDK_VERSION:" "$MACOS_SDK_VERSION"
-printf "$format" "MACOS_SDK_PATH:" "$MACOS_SDK_PATH"
-printf "$format" "MIN_MACOS_VERSION:" "$MIN_MACOS_VERSION"
-printf "$format" "MACOS_ARCHS:" "${MACOS_ARCHS[*]}"
-printf "$format" "IOS_ARCHS:" "${IOS_ARCHS[*]}"
-printf "$format" "IOS_SIM_ARCHS" "${IOS_SIM_ARCHS[*]}"
-printf "$format" "BOOST_LIBS:" "$BOOST_LIBS"
-printf "$format" "BOOST_SRC:" "$BOOST_SRC"
-printf "$format" "IOS_BUILD_DIR:" "$IOS_BUILD_DIR"
-printf "$format" "MACOS_BUILD_DIR:" "$MACOS_BUILD_DIR"
-printf "$format" "IOS_FRAMEWORK_DIR:" "$IOS_FRAMEWORK_DIR"
-printf "$format" "MACOS_FRAMEWORK_DIR:" "$MACOS_FRAMEWORK_DIR"
-printf "$format" "XCODE_ROOT:" "$XCODE_ROOT"
-printf "$format" "THREADS:" "$THREADS"
-printf "$format" "VARIANT:" "$BUILD_VARIANT"
+printVar()
+{
+    VAR_NAME="$1"
+    VALUE="${2:-${!1}}"
+    printf "%-20s: %s\n" "$VAR_NAME" "$VALUE"
+}
+asBool() { test -n "$1" && echo "YES" || echo "NO"; }
+
+printVar "BUILD_IOS" "$(asBool "$BUILD_IOS")"
+printVar "BUILD_TVOS" "$(asBool "$BUILD_TVOS")"
+printVar "BUILD_MACOS" "$(asBool "$BUILD_MACOS")"
+printVar "BOOST_VERSION"
+printVar "IOS_SDK_VERSION"
+printVar "MIN_IOS_VERSION"
+printVar "TVOS_SDK_VERSION"
+printVar "TVOS_SDK_PATH"
+printVar "TVOSSIM_SDK_PATH"
+printVar "MIN_TVOS_VERSION"
+printVar "MACOS_SDK_VERSION"
+printVar "MACOS_SDK_PATH"
+printVar "MIN_MACOS_VERSION"
+printVar "MACOS_ARCHS"
+printVar "IOS_ARCHS"
+printVar "IOS_SIM_ARCHS"
+printVar "BOOST_LIBS"
+printVar "BOOST_SRC"
+printVar "IOS_BUILD_DIR"
+printVar "MACOS_BUILD_DIR"
+printVar "IOS_FRAMEWORK_DIR"
+printVar "MACOS_FRAMEWORK_DIR"
+printVar "XCODE_ROOT"
+printVar "THREADS"
+printVar "BUILD_VARIANT"
 echo
 
 if [[ -n "$PURGE" ]]; then

--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+-- 2020-04-08 --
+* Add shellcheck to CI
+* Fix all shellcheck warnings
+
 -- 2019-09-20 --
 * Use bintray rather than sourceforge for downloads
 


### PR DESCRIPTION
This :

- Adds a GitHub Action to run shellcheck on master and PRs
- Fixes all warnings and errors of shellcheck

The problems I saw the most were :

-  Double quoting of variables
    - https://www.shellcheck.net/wiki/SC2068
    - https://www.shellcheck.net/wiki/SC2046
    - https://www.shellcheck.net/wiki/SC2206
    - https://www.shellcheck.net/wiki/SC2086
- Usage of `` `cmd ...` `` over `$(cmd ...)`
    - https://www.shellcheck.net/wiki/SC2006
- Usage of `cd` and executing command without checking if the directory actually changed
    - https://www.shellcheck.net/wiki/SC2164

The diff is quite long but should be relatively straightforward to review. Let me know if anything isn't clear :)