### PR TITLE
Fix build with Xcode 11.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,4 +12,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: shellcheck
-      uses: azohra/shell-linter@v0.2.0
+      uses: azohra/shell-linter@v0.3.0
+      with:
+          path: "*.sh"

--- a/changelog
+++ b/changelog
@@ -1,6 +1,10 @@
+-- 2020-04-18 --
+* Updated default boost version to 1.72.0
+* Fixed error "unknown argument: '-fcoalesce-templates'" when building with Xcode 11.4 (#45)
+
 -- 2020-04-08 --
-* Add shellcheck to CI
-* Fix all shellcheck warnings
+* Added shellcheck to CI
+* Fixed all shellcheck warnings
 
 -- 2019-09-20 --
 * Use bintray rather than sourceforge for downloads

--- a/patches/xcode-11.4.patch
+++ b/patches/xcode-11.4.patch
@@ -1,0 +1,31 @@
+From 40960b23338da0a359d6aa83585ace09ad8804d2 Mon Sep 17 00:00:00 2001
+From: Bo Anderson <mail@boanderson.me>
+Date: Sun, 29 Mar 2020 14:55:08 +0100
+Subject: [PATCH] Fix compiler version check on macOS
+
+Fixes #440.
+---
+ src/tools/darwin.jam | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/darwin.jam b/src/tools/darwin.jam
+index 8d477410b0..97e7ecb851 100644
+--- a/src/tools/darwin.jam
++++ b/src/tools/darwin.jam
+@@ -137,13 +137,14 @@ rule init ( version ? : command * : options * : requirement * )
+     # - Set the toolset generic common options.
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+     
++    real-version = [ regex.split $(real-version) \\. ] ;
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
++    if [ version.version-less $(real-version) : 4 0 ]
+     {
+         flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+     }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+-    if $(real-version) < "4.2.0"
++    if [ version.version-less $(real-version) : 4 2 ]
+     {
+         flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
+     }


### PR DESCRIPTION
This fixes #45 .

As discussed in #47 , the patch from https://github.com/boostorg/build/pull/560 is applied before building.

The patch is only applied to boost versions `<= 1.72.0` (expecting the problem to be fixed in the next boost release since the PR was merged), and when compiling with Xcode `>= 11.4`.