### PR TITLE
Cleanup user-config.jam patch

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -1222,29 +1222,36 @@ printVar()
 }
 asBool() { test -n "$1" && echo "YES" || echo "NO"; }
 
-printVar "BUILD_IOS" "$(asBool "$BUILD_IOS")"
-printVar "BUILD_TVOS" "$(asBool "$BUILD_TVOS")"
-printVar "BUILD_MACOS" "$(asBool "$BUILD_MACOS")"
 printVar "BOOST_VERSION"
+echo
+printVar "BUILD_IOS" "$(asBool "$BUILD_IOS")"
+printVar "IOS_ARCHS"
 printVar "IOS_SDK_VERSION"
+printVar "IOS_SDK_PATH"
+printVar "IOSSIM_SDK_PATH"
 printVar "MIN_IOS_VERSION"
+echo
+printVar "BUILD_TVOS" "$(asBool "$BUILD_TVOS")"
 printVar "TVOS_SDK_VERSION"
 printVar "TVOS_SDK_PATH"
 printVar "TVOSSIM_SDK_PATH"
 printVar "MIN_TVOS_VERSION"
+echo
+printVar "BUILD_MACOS" "$(asBool "$BUILD_MACOS")"
+printVar "MACOS_ARCHS"
 printVar "MACOS_SDK_VERSION"
 printVar "MACOS_SDK_PATH"
 printVar "MIN_MACOS_VERSION"
-printVar "MACOS_ARCHS"
-printVar "IOS_ARCHS"
-printVar "IOS_SIM_ARCHS"
+echo
 printVar "BOOST_LIBS"
 printVar "BOOST_SRC"
+printVar "XCODE_ROOT"
 printVar "IOS_BUILD_DIR"
+printVar "TVOS_BUILD_DIR"
 printVar "MACOS_BUILD_DIR"
+printVar "TVOS_FRAMEWORK_DIR"
 printVar "IOS_FRAMEWORK_DIR"
 printVar "MACOS_FRAMEWORK_DIR"
-printVar "XCODE_ROOT"
 printVar "THREADS"
 printVar "BUILD_VARIANT"
 echo

--- a/boost.sh
+++ b/boost.sh
@@ -43,12 +43,17 @@ system test thread timer type_erasure wave"
 BOOTSTRAP_LIBS=""
 
 MIN_IOS_VERSION=11.0
+IOS_SDK_VERSION=$(xcrun --sdk iphoneos --show-sdk-version)
+IOS_SDK_PATH=$(xcrun --sdk iphoneos --show-sdk-path)
+IOSSIM_SDK_PATH=$(xcrun --sdk iphonesimulator --show-sdk-path)
 
 MIN_TVOS_VERSION=11.0
+TVOS_SDK_VERSION=$(xcrun --sdk appletvos --show-sdk-version)
 TVOS_SDK_PATH=$(xcrun --sdk appletvos --show-sdk-path)
 TVOSSIM_SDK_PATH=$(xcrun --sdk appletvsimulator --show-sdk-path)
 
 MIN_MACOS_VERSION=10.12
+MACOS_SDK_VERSION=$(xcrun --sdk macosx --show-sdk-version)
 MACOS_SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
 
 MACOS_ARCHS=("x86_64")
@@ -56,7 +61,9 @@ IOS_ARCHS=("armv7" "arm64")
 IOS_SIM_ARCHS=("i386" "x86_64")
 
 # Applied to all platforms
-CXX_FLAGS="-std=c++14 -stdlib=libc++"
+CXX_FLAGS=""
+LD_FLAGS=""
+OTHER_FLAGS="-std=c++14 -stdlib=libc++ -DNDEBUG"
 
 XCODE_VERSION=$(xcrun xcodebuild -version | head -n1 | tr -Cd '[:digit:].')
 XCODE_ROOT=$(xcode-select -print-path)
@@ -67,9 +74,9 @@ THREADS="-j$(sysctl -n hw.ncpu)"
 CURRENT_DIR=$(pwd)
 SRCDIR="$CURRENT_DIR/src"
 
-IOS_ARM_DEV_CMD="xcrun --sdk iphoneos"
+IOS_DEV_CMD="xcrun --sdk iphoneos"
 IOS_SIM_DEV_CMD="xcrun --sdk iphonesimulator"
-TVOS_ARM_DEV_CMD="xcrun --sdk appletvos"
+TVOS_DEV_CMD="xcrun --sdk appletvos"
 TVOS_SIM_DEV_CMD="xcrun --sdk appletvsimulator"
 MACOS_DEV_CMD="xcrun --sdk macosx"
 
@@ -596,48 +603,55 @@ updateBoost()
         USING_MPI="using mpi ;" # trailing space needed
     fi
 
-    if [[ "$1" == "iOS" ]]; then
-        cat > "$BOOST_SRC/tools/build/src/user-config.jam" <<EOF
-using darwin : ${IOS_SDK_VERSION}~iphone
-: $COMPILER ${IOS_ARCH_FLAGS[*]} $EXTRA_IOS_FLAGS
-: <striper> <root>$XCODE_ROOT/Platforms/iPhoneOS.platform/Developer
-: <architecture>arm <target-os>iphone
-;
-using darwin : ${IOS_SDK_VERSION}~iphonesim
-: $COMPILER ${IOS_SIM_ARCH_FLAGS[*]} $EXTRA_IOS_SIM_FLAGS
-: <striper> <root>$XCODE_ROOT/Platforms/iPhoneSimulator.platform/Developer
-: <architecture>x86 <target-os>iphone
-;
-$USING_MPI
-EOF
-    fi
+    cat > "$BOOST_SRC/tools/build/src/user-config.jam" <<EOF
+using darwin : $COMPILER_VERSION~iphone
+: $COMPILER
+: <architecture>arm
+  <target-os>iphone
+  <cxxflags>"$CXX_FLAGS"
+  <linkflags>"$LD_FLAGS"
+  <compileflags>"$OTHER_FLAGS ${IOS_ARCH_FLAGS[*]} $EXTRA_IOS_FLAGS -isysroot $IOS_SDK_PATH"
+  <threading>multi
 
-    if [[ "$1" == "tvOS" ]]; then
-        cat > "$BOOST_SRC/tools/build/src/user-config.jam" <<EOF
-using darwin : ${TVOS_SDK_VERSION}~appletv
-: $COMPILER -arch arm64 $EXTRA_TVOS_FLAGS -isysroot $TVOS_SDK_PATH -I $TVOS_SDK_PATH
-: <striper> <root>$XCODE_ROOT/Platforms/AppleTVOS.platform/Developer
-: <architecture>arm <target-os>iphone
 ;
-using darwin : ${TVOS_SDK_VERSION}~appletvsim
-: $COMPILER -arch x86_64 $EXTRA_TVOS_SIM_FLAGS -isysroot $TVOSSIM_SDK_PATH -I $TVOSSIM_SDK_PATH
-: <striper> <root>$XCODE_ROOT/Platforms/AppleTVSimulator.platform/Developer
-: <architecture>x86 <target-os>iphone
+using darwin : $COMPILER_VERSION~iphonesim
+: $COMPILER
+: <architecture>x86
+  <target-os>iphone
+  <cxxflags>"$CXX_FLAGS"
+  <linkflags>"$LD_FLAGS"
+  <compileflags>"$OTHER_FLAGS ${IOS_SIM_ARCH_FLAGS[*]} $EXTRA_IOS_SIM_FLAGS -isysroot $IOSSIM_SDK_PATH"
+  <threading>multi
+;
+using darwin : $COMPILER_VERSION~appletv
+: $COMPILER
+: <architecture>arm
+  <target-os>iphone
+  <cxxflags>"$CXX_FLAGS"
+  <linkflags>"$LD_FLAGS"
+  <compileflags>"$OTHER_FLAGS -arch arm64 $EXTRA_TVOS_FLAGS -isysroot $TVOS_SDK_PATH"
+  <threading>multi
+;
+using darwin : $COMPILER_VERSION~appletvsim
+: $COMPILER
+: <architecture>x86
+  <target-os>iphone
+  <cxxflags>"$CXX_FLAGS"
+  <linkflags>"$LD_FLAGS"
+  <compileflags>"$OTHER_FLAGS -arch x86_64 $EXTRA_TVOS_SIM_FLAGS -isysroot $TVOSSIM_SDK_PATH"
+  <threading>multi
+;
+using darwin : $COMPILER_VERSION~macos
+: $COMPILER
+: <architecture>x86
+  <target-os>darwin
+  <cxxflags>"$CXX_FLAGS"
+  <linkflags>"$LD_FLAGS"
+  <compileflags>"$OTHER_FLAGS ${MACOS_ARCH_FLAGS[*]} $EXTRA_MACOS_FLAGS -isysroot $MACOS_SDK_PATH"
+  <threading>multi
 ;
 $USING_MPI
 EOF
-    fi
-
-    if [[ "$1" == "macOS" ]]; then
-        cat > "$BOOST_SRC/tools/build/src/user-config.jam" <<EOF
-using darwin : ${MACOS_SDK_VERSION}
-: $COMPILER ${MACOS_ARCH_FLAGS[*]} $EXTRA_MACOS_FLAGS -isysroot $MACOS_SDK_PATH
-: <striper> <root>$XCODE_ROOT/Platforms/MacOSX.platform/Developer
-: <architecture>x86 <target-os>darwin
-;
-$USING_MPI
-EOF
-    fi
 
     doneSection
 }
@@ -689,29 +703,37 @@ buildBoost_iOS()
 
     echo Building Boost for iPhone
     # Install this one so we can copy the headers for the frameworks...
-    ./b2 "$THREADS" --build-dir=iphone-build --stagedir=iphone-build/stage \
-        --prefix="$IOS_OUTPUT_DIR/prefix" toolset=darwin \
-        cxxflags="${CXX_FLAGS} ${IOS_ARCH_FLAGS[*]}" architecture=arm target-os=iphone linkflags="-stdlib=libc++" \
-        macosx-version="iphone-$IOS_SDK_VERSION" define=_LITTLE_ENDIAN \
-        link=static variant=${BUILD_VARIANT} stage >> "${IOS_OUTPUT_DIR}/ios-build.log" 2>&1
+    ./b2 "$THREADS" \
+        --build-dir=iphone-build \
+        --stagedir=iphone-build/stage \
+        --prefix="$IOS_OUTPUT_DIR/prefix" \
+        toolset="darwin-$COMPILER_VERSION~iphone" \
+        link=static \
+        variant=${BUILD_VARIANT} \
+        stage >> "${IOS_OUTPUT_DIR}/ios-build.log" 2>&1
     # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging iPhone. Check log."; exit 1; fi
 
-    ./b2 "$THREADS" --build-dir=iphone-build --stagedir=iphone-build/stage \
-        --prefix="$IOS_OUTPUT_DIR/prefix" toolset=darwin \
-        cxxflags="${CXX_FLAGS} ${IOS_ARCH_FLAGS[*]}" architecture=arm linkflags="-stdlib=libc++" \
-        target-os=iphone macosx-version="iphone-$IOS_SDK_VERSION" \
-        define=_LITTLE_ENDIAN link=static variant=${BUILD_VARIANT} install >> "${IOS_OUTPUT_DIR}/ios-build.log" 2>&1
+    ./b2 "$THREADS" \
+        --build-dir=iphone-build \
+        --stagedir=iphone-build/stage \
+        --prefix="$IOS_OUTPUT_DIR/prefix" \
+        toolset="darwin-$COMPILER_VERSION~iphone" \
+        link=static \
+        variant=${BUILD_VARIANT} \
+        install >> "${IOS_OUTPUT_DIR}/ios-build.log" 2>&1
     # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error installing iPhone. Check log."; exit 1; fi
     doneSection
 
     echo Building Boost for iPhoneSimulator
-    ./b2 "$THREADS" --build-dir=iphonesim-build --stagedir=iphonesim-build/stage \
-        toolset="darwin-{IOS_SDK_VERSION}~iphonesim" \
-        cxxflags="${CXX_FLAGS} ${IOS_SIM_ARCH_FLAGS[*]}" architecture=x86 linkflags="-stdlib=libc++" \
-        target-os=iphone macosx-version="iphonesim-$IOS_SDK_VERSION" \
-        link=static variant=${BUILD_VARIANT} stage >> "${IOS_OUTPUT_DIR}/ios-build.log" 2>&1
+    ./b2 "$THREADS"  \
+        --build-dir=iphonesim-build \
+        --stagedir=iphonesim-build/stage \
+        toolset="darwin-$COMPILER_VERSION~iphonesim" \
+        link=static \
+        variant=${BUILD_VARIANT} \
+        stage >> "${IOS_OUTPUT_DIR}/ios-build.log" 2>&1
     # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging iPhoneSimulator. Check log."; exit 1; fi
     doneSection
@@ -723,25 +745,37 @@ buildBoost_tvOS()
     mkdir -p "$TVOS_OUTPUT_DIR"
 
     echo Building Boost for AppleTV
-    ./b2 "$THREADS" --build-dir=appletv-build --stagedir=appletv-build/stage \
-        --prefix="$TVOS_OUTPUT_DIR/prefix" toolset="darwin-$TVOS_SDK_VERSION~appletv" \
-        cxxflags="${CXX_FLAGS}" architecture=arm target-os=iphone define=_LITTLE_ENDIAN linkflags="-stdlib=libc++" \
-        link=static variant=${BUILD_VARIANT} stage >> "${TVOS_OUTPUT_DIR}/tvos-build.log" 2>&1
+    ./b2 "$THREADS" \
+        --build-dir=appletv-build \
+        --stagedir=appletv-build/stage \
+        --prefix="$TVOS_OUTPUT_DIR/prefix" \
+        toolset="darwin-$COMPILER_VERSION~appletv" \
+        link=static \
+        variant=${BUILD_VARIANT} \
+        stage >> "${TVOS_OUTPUT_DIR}/tvos-build.log" 2>&1
     # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging AppleTV. Check log."; exit 1; fi
 
-    ./b2 "$THREADS" --build-dir=appletv-build --stagedir=appletv-build/stage \
-        --prefix="$TVOS_OUTPUT_DIR/prefix" toolset="darwin-$TVOS_SDK_VERSION~appletv" \
-        cxxflags="${CXX_FLAGS}" architecture=arm target-os=iphone define=_LITTLE_ENDIAN linkflags="-stdlib=libc++" \
-        link=static variant=${BUILD_VARIANT} install >> "${TVOS_OUTPUT_DIR}/tvos-build.log" 2>&1
+    ./b2 "$THREADS" \
+        --build-dir=appletv-build \
+        --stagedir=appletv-build/stage \
+        --prefix="$TVOS_OUTPUT_DIR/prefix" \
+        toolset="darwin-$COMPILER_VERSION~appletv" \
+        link=static \
+        variant=${BUILD_VARIANT} \
+        install >> "${TVOS_OUTPUT_DIR}/tvos-build.log" 2>&1
     # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error installing AppleTV. Check log."; exit 1; fi
     doneSection
 
-    echo Building Boost for AppleTVSimulator
-    ./b2 "$THREADS" --build-dir=appletv-build --stagedir=appletvsim-build/stage \
-        toolset="darwin-$TVOS_SDK_VERSION~appletvsim" architecture=x86 \
-        cxxflags="${CXX_FLAGS}" target-os=iphone link=static variant=${BUILD_VARIANT} linkflags="-stdlib=libc++" \
+    echo "Building Boost for AppleTVSimulator"
+    ./b2 "$THREADS"  \
+        --build-dir=appletvsim-build \
+        --stagedir=appletvsim-build/stage \
+        --prefix="$TVOS_OUTPUT_DIR/prefix" \
+        toolset="darwin-$COMPILER_VERSION~appletvsim" \
+        link=static \
+        variant=${BUILD_VARIANT} \
         stage >> "${TVOS_OUTPUT_DIR}/tvos-build.log" 2>&1
     # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging AppleTVSimulator. Check log."; exit 1; fi
@@ -754,19 +788,25 @@ buildBoost_macOS()
     mkdir -p "$MACOS_OUTPUT_DIR"
 
     echo building Boost for macOS
-    ./b2 "$THREADS" --build-dir=macos-build --stagedir=macos-build/stage --prefix="$MACOS_OUTPUT_DIR/prefix" \
-        toolset="darwin-$MACOS_SDK_VERSION" architecture=x86  \
-        cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS[*]} ${EXTRA_MACOS_SDK_FLAGS}" \
-        linkflags="-stdlib=libc++ ${EXTRA_MACOS_SDK_FLAGS}" link=static variant=${BUILD_VARIANT} threading=multi \
-        macosx-version="${MACOS_SDK_VERSION}" stage >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
+    ./b2 "$THREADS" \
+        --build-dir=macos-build \
+        --stagedir=macos-build/stage \
+        --prefix="$MACOS_OUTPUT_DIR/prefix" \
+        toolset="darwin-$COMPILER_VERSION~macos" \
+        link=static \
+        variant=${BUILD_VARIANT} \
+        stage >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
     # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error staging macOS. Check log."; exit 1; fi
 
-    ./b2 "$THREADS" --build-dir=macos-build --stagedir=macos-build/stage --prefix="$MACOS_OUTPUT_DIR/prefix" \
-        toolset="darwin-$MACOS_SDK_VERSION" architecture=x86  \
-        cxxflags="${CXX_FLAGS} ${MACOS_ARCH_FLAGS[*]} ${EXTRA_MACOS_SDK_FLAGS}" \
-        linkflags="-stdlib=libc++ ${EXTRA_MACOS_SDK_FLAGS}" link=static variant=${BUILD_VARIANT} threading=multi \
-        macosx-version="$MACOS_SDK_VERSION" install >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
+    ./b2 "$THREADS" \
+        --build-dir=macos-build \
+        --stagedir=macos-build/stage \
+        --prefix="$MACOS_OUTPUT_DIR/prefix" \
+        toolset="darwin-$COMPILER_VERSION~macos" \
+        link=static \
+        variant=${BUILD_VARIANT} \
+        install >> "${MACOS_OUTPUT_DIR}/macos-build.log" 2>&1
     # shellcheck disable=SC2181
     if [ $? != 0 ]; then echo "Error installing macOS. Check log."; exit 1; fi
 
@@ -844,7 +884,7 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
         if [[ -n $BUILD_IOS ]]; then
             if [[ "${#IOS_ARCHS[@]}" -gt 1 ]]; then
                 for ARCH in "${IOS_ARCHS[@]}"; do
-                    $IOS_ARM_DEV_CMD lipo "iphone-build/stage/lib/libboost_$NAME.a" \
+                    $IOS_DEV_CMD lipo "iphone-build/stage/lib/libboost_$NAME.a" \
                         -thin "$ARCH" -o "$IOS_BUILD_DIR/$ARCH/libboost_$NAME.a"
                 done
             else
@@ -941,7 +981,7 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
         if [[ -n $BUILD_IOS ]]; then
             for ARCH in "${IOS_ARCHS[@]}"; do
                 echo "...ios-$ARCH"
-                (cd_or_abort "$IOS_BUILD_DIR/$ARCH"; $IOS_ARM_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
+                (cd_or_abort "$IOS_BUILD_DIR/$ARCH"; $IOS_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
             done
 
             for ARCH in "${IOS_SIM_ARCHS[@]}"; do
@@ -952,7 +992,7 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
 
         if [[ -n $BUILD_TVOS ]]; then
             echo "...tvOS-arm64"
-            (cd_or_abort "$TVOS_BUILD_DIR/arm64"; $TVOS_ARM_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
+            (cd_or_abort "$TVOS_BUILD_DIR/arm64"; $TVOS_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
             echo "...tvOS-x86_64"
             (cd_or_abort "$TVOS_BUILD_DIR/x86_64";  $TVOS_SIM_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
         fi
@@ -987,7 +1027,7 @@ buildUniversal()
             done
             if [[ "${#ARCH_FILES[@]}" -gt 0 ]]; then
                 echo "... $NAME"
-                $IOS_ARM_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
+                $IOS_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
             fi
         done
     fi
@@ -1009,7 +1049,7 @@ buildUniversal()
             fi
             if [[ "${#ARCH_FILES[@]}" -gt 0 ]]; then
                 echo "... $NAME"
-                $TVOS_ARM_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
+                $TVOS_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
             fi
         done
     fi
@@ -1028,7 +1068,7 @@ buildUniversal()
             done
             if [[ "${#ARCH_FILES[@]}" -gt 0 ]]; then
                 echo "... $NAME"
-                $TVOS_ARM_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
+                $TVOS_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
             fi
         done
     fi
@@ -1075,10 +1115,10 @@ buildFramework()
         echo "Lipoing library into $FRAMEWORK_INSTALL_NAME..."
         cd_or_abort "$BUILDDIR"
         if [[ -n $BUILD_IOS ]]; then
-            $IOS_ARM_DEV_CMD lipo -create ./*/libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
+            $IOS_DEV_CMD lipo -create ./*/libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
         fi
         if [[ -n $BUILD_TVOS ]]; then
-            $TVOS_ARM_DEV_CMD lipo -create ./*/libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
+            $TVOS_DEV_CMD lipo -create ./*/libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
         fi
         if [[ -n $BUILD_MACOS ]]; then
             $MACOS_DEV_CMD lipo -create ./*/libboost.a -o "$FRAMEWORK_INSTALL_NAME" || abort "Lipo $1 failed"
@@ -1144,7 +1184,6 @@ EXTRA_IOS_SIM_FLAGS="$EXTRA_FLAGS $EXTRA_ARM_FLAGS -mios-simulator-version-min=$
 EXTRA_TVOS_FLAGS="$EXTRA_FLAGS $EXTRA_ARM_FLAGS -mtvos-version-min=$MIN_TVOS_VERSION"
 EXTRA_TVOS_SIM_FLAGS="$EXTRA_FLAGS $EXTRA_ARM_FLAGS -mtvos-simulator-version-min=$MIN_TVOS_VERSION"
 EXTRA_MACOS_FLAGS="$EXTRA_FLAGS -mmacosx-version-min=$MIN_MACOS_VERSION"
-EXTRA_MACOS_SDK_FLAGS="-isysroot ${MACOS_SDK_PATH} -mmacosx-version-min=${MIN_MACOS_VERSION}"
 
 BOOST_VERSION2="${BOOST_VERSION//./_}"
 BOOST_TARBALL="$CURRENT_DIR/boost_$BOOST_VERSION2.tar.bz2"

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+-- 2020-05-31 --
+* Cleanup build commands and patch of Boost's user-config.jam
+
 -- 2020-04-18 --
 * Updated default boost version to 1.72.0
 * Fixed error "unknown argument: '-fcoalesce-templates'" when building with Xcode 11.4 (#45)


### PR DESCRIPTION
- Define the same variables for all targets (iOS, tvOS, macOS)
- Use the right variables for each compiler flag (CXX, LD, etc.)
- Move flags passed to the compiler from build functions to user-config.jam patch to reduce code duplication
  - This will also be needed to easily add support for [bcp](https://www.boost.org/doc/libs/1_69_0/tools/bcp/doc/html/index.html)
- Cleanup variables values dump at beginning of script

-------------------

<details> 
  <summary>Variables dump before / after </summary>

#### Before
```bash
BUILD_IOS           : YES
BUILD_TVOS          : YES
BUILD_MACOS         : YES
BOOST_VERSION       : 1.72.0
IOS_SDK_VERSION     : 13.4
MIN_IOS_VERSION     : 11.0
TVOS_SDK_VERSION    : 13.4
TVOS_SDK_PATH       : /Applications/Xcode-11.4.1.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS13.4.sdk
TVOSSIM_SDK_PATH    : /Applications/Xcode-11.4.1.app/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator13.4.sdk
MIN_TVOS_VERSION    : 11.0
MACOS_SDK_VERSION   : 10.15
MACOS_SDK_PATH      : /Applications/Xcode-11.4.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
MIN_MACOS_VERSION   : 10.12
MACOS_ARCHS         : x86_64
IOS_ARCHS           : arm64
IOS_SIM_ARCHS       : x86_64
BOOST_LIBS          : atomic chrono date_time exception filesystem program_options random system thread test
BOOST_SRC           : /Users/guillaume/Apple-Boost-BuildScript/src/boost_1_72_0
IOS_BUILD_DIR       : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/ios/release/build
MACOS_BUILD_DIR     : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/macos/release/build
IOS_FRAMEWORK_DIR   : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/ios/release/framework
MACOS_FRAMEWORK_DIR : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/macos/release/framework
XCODE_ROOT          : /Applications/Xcode-11.4.1.app/Contents/Developer
THREADS             : -j4
BUILD_VARIANT       : release
```

#### After
```bash
BOOST_VERSION       : 1.72.0

BUILD_IOS           : YES
IOS_ARCHS           : arm64
IOS_SDK_VERSION     : 13.4
IOS_SDK_PATH        : /Applications/Xcode-11.4.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.4.sdk
IOSSIM_SDK_PATH     : /Applications/Xcode-11.4.1.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator13.4.sdk
MIN_IOS_VERSION     : 11.0

BUILD_TVOS          : YES
TVOS_SDK_VERSION    : 13.4
TVOS_SDK_PATH       : /Applications/Xcode-11.4.1.app/Contents/Developer/Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS13.4.sdk
TVOSSIM_SDK_PATH    : /Applications/Xcode-11.4.1.app/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/SDKs/AppleTVSimulator13.4.sdk
MIN_TVOS_VERSION    : 11.0

BUILD_MACOS         : YES
MACOS_ARCHS         : x86_64
MACOS_SDK_VERSION   : 10.15
MACOS_SDK_PATH      : /Applications/Xcode-11.4.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk
MIN_MACOS_VERSION   : 10.12

BOOST_LIBS          : atomic chrono date_time exception filesystem program_options random system thread test
BOOST_SRC           : /Users/guillaume/Apple-Boost-BuildScript/src/boost_1_72_0
XCODE_ROOT          : /Applications/Xcode-11.4.1.app/Contents/Developer
IOS_BUILD_DIR       : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/ios/release/build
TVOS_BUILD_DIR      : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/tvos/release/build
MACOS_BUILD_DIR     : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/macos/release/build
TVOS_FRAMEWORK_DIR  : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/tvos/release/framework
IOS_FRAMEWORK_DIR   : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/ios/release/framework
MACOS_FRAMEWORK_DIR : /Users/guillaume/Apple-Boost-BuildScript/build/boost/1.72.0/macos/release/framework
THREADS             : -j4
BUILD_VARIANT       : release
```
</details>