### PR TITLE
Add Catalyst support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,10 +8,95 @@ on:
 
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: shellcheck
-      uses: azohra/shell-linter@v0.3.0
+      uses: azohra/shell-linter@v0.4.0
       with:
           path: "*.sh"
+
+  build-boost:
+    name: Build boost
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: bash boost.sh
+    - name: Upload built boost.xcframework
+      uses: actions/upload-artifact@v2
+      with:
+        name: boost.xcframework
+        path: dist/boost.xcframework
+
+  build-macOS:
+    name: Build macOS (native)
+    needs: build-boost
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download boost.xcframework from job build-boost
+      uses: actions/download-artifact@v2
+      with:
+        name: boost.xcframework
+        path: dist/boost.xcframework
+    - uses: sersoft-gmbh/xcodebuild-action@v1.1
+      with:
+          project: SampleBoostApp/SampleBoostApp.xcodeproj
+          scheme: SampleBoostApp_macOS
+          destination: platform=macOS
+          action: build
+
+  build-macOS-catalyst:
+    name: Build macOS (Catalyst)
+    needs: build-boost
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download boost.xcframework from job build-boost
+      uses: actions/download-artifact@v2
+      with:
+        name: boost.xcframework
+        path: dist/boost.xcframework
+    - uses: sersoft-gmbh/xcodebuild-action@v1.1
+      with:
+          project: SampleBoostApp/SampleBoostApp.xcodeproj
+          scheme: SampleBoostApp_iOS
+          destination: platform=macOS
+          action: build
+
+  build-iOS:
+    name: Build iOS
+    needs: build-boost
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download boost.xcframework from job build-boost
+      uses: actions/download-artifact@v2
+      with:
+        name: boost.xcframework
+        path: dist/boost.xcframework
+    - uses: sersoft-gmbh/xcodebuild-action@v1.1
+      with:
+          project: SampleBoostApp/SampleBoostApp.xcodeproj
+          scheme: SampleBoostApp_iOS
+          destination: platform=iOS Simulator,name=iPhone 11
+          action: build
+
+  build-tvOS:
+    name: Build tvOS
+    needs: build-boost
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download boost.xcframework from job build-boost
+      uses: actions/download-artifact@v2
+      with:
+        name: boost.xcframework
+        path: dist/boost.xcframework
+    - uses: sersoft-gmbh/xcodebuild-action@v1.1
+      with:
+          project: SampleBoostApp/SampleBoostApp.xcodeproj
+          scheme: SampleBoostApp_tvOS
+          destination: platform=tvOS Simulator,name=Apple TV
+          action: build

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,44 @@ src/
 build/
 *.tar.bz2
 
+# Created by https://www.toptal.com/developers/gitignore/api/xcode,macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=xcode,macos
+
+### macOS ###
+# General
 .DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Xcode ###
+## User settings
+xcuserdata/
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+**/xcshareddata/WorkspaceSettings.xcsettings

--- a/SampleBoostApp/SampleBoostApp.xcodeproj/project.pbxproj
+++ b/SampleBoostApp/SampleBoostApp.xcodeproj/project.pbxproj
@@ -1,0 +1,548 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 52;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F060B76D24CDC47300E79C7B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F060B76B24CDC47300E79C7B /* AppDelegate.m */; };
+		F060B76E24CDC47300E79C7B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F060B76C24CDC47300E79C7B /* main.m */; };
+		F060B79324CDC4CA00E79C7B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F060B79024CDC4CA00E79C7B /* main.m */; };
+		F060B79424CDC4CA00E79C7B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F060B79224CDC4CA00E79C7B /* AppDelegate.m */; };
+		F060B7BC24CDC60600E79C7B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F060B76B24CDC47300E79C7B /* AppDelegate.m */; };
+		F060B7BD24CDC60600E79C7B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F060B76C24CDC47300E79C7B /* main.m */; };
+		F060B7C824CDC7BB00E79C7B /* ABBVegetable.mm in Sources */ = {isa = PBXBuildFile; fileRef = F060B7C724CDC7BB00E79C7B /* ABBVegetable.mm */; };
+		F060B7C924CDC7BB00E79C7B /* ABBVegetable.mm in Sources */ = {isa = PBXBuildFile; fileRef = F060B7C724CDC7BB00E79C7B /* ABBVegetable.mm */; };
+		F060B7CA24CDC7BB00E79C7B /* ABBVegetable.mm in Sources */ = {isa = PBXBuildFile; fileRef = F060B7C724CDC7BB00E79C7B /* ABBVegetable.mm */; };
+		F060B7D024CDCCD100E79C7B /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F060B7CF24CDCCD100E79C7B /* SceneDelegate.m */; };
+		F060B7D124CDCCD100E79C7B /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F060B7CF24CDCCD100E79C7B /* SceneDelegate.m */; };
+		F060B7DA24CDE09D00E79C7B /* boost.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F060B7D424CDE08700E79C7B /* boost.xcframework */; };
+		F060B7DE24CDE0A400E79C7B /* boost.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F060B7D424CDE08700E79C7B /* boost.xcframework */; };
+		F060B7E124CDE0A700E79C7B /* boost.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = F060B7D424CDE08700E79C7B /* boost.xcframework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		35D06C0B1F6D09EA29EE663B /* SampleBoostApp_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleBoostApp_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		40F4D5481BADB61C367F6550 /* SampleBoostApp_tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleBoostApp_tvOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		6EC669783594B8F6222C8CF0 /* SampleBoostApp_macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SampleBoostApp_macOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F060B76A24CDC47300E79C7B /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		F060B76B24CDC47300E79C7B /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		F060B76C24CDC47300E79C7B /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		F060B79024CDC4CA00E79C7B /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		F060B79124CDC4CA00E79C7B /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		F060B79224CDC4CA00E79C7B /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		F060B79624CDC50D00E79C7B /* SampleBoostApp_Catalyst.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SampleBoostApp_Catalyst.entitlements; sourceTree = "<group>"; };
+		F060B79724CDC50D00E79C7B /* SampleBoostApp_macOS.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SampleBoostApp_macOS.entitlements; sourceTree = "<group>"; };
+		F060B7C024CDC61900E79C7B /* Info_iOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info_iOS.plist; sourceTree = "<group>"; };
+		F060B7C124CDC61900E79C7B /* Info_macOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info_macOS.plist; sourceTree = "<group>"; };
+		F060B7C624CDC7BB00E79C7B /* ABBVegetable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ABBVegetable.h; sourceTree = "<group>"; };
+		F060B7C724CDC7BB00E79C7B /* ABBVegetable.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ABBVegetable.mm; sourceTree = "<group>"; };
+		F060B7CE24CDCCD100E79C7B /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
+		F060B7CF24CDCCD100E79C7B /* SceneDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SceneDelegate.m; sourceTree = "<group>"; };
+		F060B7D424CDE08700E79C7B /* boost.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = boost.xcframework; path = ../dist/boost.xcframework; sourceTree = SOURCE_ROOT; };
+		F078954E24CDE9A900B6FA05 /* Launch Screen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = "Launch Screen.storyboard"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F060B7D824CDE09400E79C7B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F060B7DE24CDE0A400E79C7B /* boost.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F060B7DC24CDE09D00E79C7B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F060B7DA24CDE09D00E79C7B /* boost.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F060B7E324CDE0A800E79C7B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F060B7E124CDE0A700E79C7B /* boost.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		112EA741F3C0CE213A952A2B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				35D06C0B1F6D09EA29EE663B /* SampleBoostApp_iOS.app */,
+				6EC669783594B8F6222C8CF0 /* SampleBoostApp_macOS.app */,
+				40F4D5481BADB61C367F6550 /* SampleBoostApp_tvOS.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9D2BCC43259F0A66855AE189 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				F060B7C524CDC75F00E79C7B /* Shared */,
+				F060B76F24CDC47700E79C7B /* macOS */,
+				F060B76924CDC44300E79C7B /* iOS */,
+				F060B74224CDC38600E79C7B /* Supporting Files */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		E06EBEB19BFF627FE92BF365 = {
+			isa = PBXGroup;
+			children = (
+				9D2BCC43259F0A66855AE189 /* Sources */,
+				F060B7D324CDE08700E79C7B /* Dependencies */,
+				112EA741F3C0CE213A952A2B /* Products */,
+				F060B7D524CDE09400E79C7B /* Frameworks */,
+			);
+			sourceTree = "<group>";
+		};
+		F060B74224CDC38600E79C7B /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				F060B7C024CDC61900E79C7B /* Info_iOS.plist */,
+				F060B7C124CDC61900E79C7B /* Info_macOS.plist */,
+				F060B79624CDC50D00E79C7B /* SampleBoostApp_Catalyst.entitlements */,
+				F060B79724CDC50D00E79C7B /* SampleBoostApp_macOS.entitlements */,
+			);
+			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		F060B76924CDC44300E79C7B /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				F060B76A24CDC47300E79C7B /* AppDelegate.h */,
+				F060B76B24CDC47300E79C7B /* AppDelegate.m */,
+				F060B7CE24CDCCD100E79C7B /* SceneDelegate.h */,
+				F060B7CF24CDCCD100E79C7B /* SceneDelegate.m */,
+				F060B76C24CDC47300E79C7B /* main.m */,
+				F078954E24CDE9A900B6FA05 /* Launch Screen.storyboard */,
+			);
+			path = iOS;
+			sourceTree = "<group>";
+		};
+		F060B76F24CDC47700E79C7B /* macOS */ = {
+			isa = PBXGroup;
+			children = (
+				F060B79124CDC4CA00E79C7B /* AppDelegate.h */,
+				F060B79224CDC4CA00E79C7B /* AppDelegate.m */,
+				F060B79024CDC4CA00E79C7B /* main.m */,
+			);
+			path = macOS;
+			sourceTree = "<group>";
+		};
+		F060B7C524CDC75F00E79C7B /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				F060B7C624CDC7BB00E79C7B /* ABBVegetable.h */,
+				F060B7C724CDC7BB00E79C7B /* ABBVegetable.mm */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+		F060B7D324CDE08700E79C7B /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				F060B7D424CDE08700E79C7B /* boost.xcframework */,
+			);
+			name = Dependencies;
+			sourceTree = "<group>";
+		};
+		F060B7D524CDE09400E79C7B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A2245B3C427CEDDD5F9E3399 /* SampleBoostApp_iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AB80C25D9FBE243AE9EB80D /* Build configuration list for PBXNativeTarget "SampleBoostApp_iOS" */;
+			buildPhases = (
+				3C2652DB1C0A497AABB66829 /* Sources */,
+				F060B7D824CDE09400E79C7B /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SampleBoostApp_iOS;
+			productName = SampleBoostApp_iOS;
+			productReference = 35D06C0B1F6D09EA29EE663B /* SampleBoostApp_iOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		D99702ECD26652F5D824F020 /* SampleBoostApp_tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FE7CEC9B446C56F76F119898 /* Build configuration list for PBXNativeTarget "SampleBoostApp_tvOS" */;
+			buildPhases = (
+				A278816A9BB85E3890C65F92 /* Sources */,
+				F060B7E324CDE0A800E79C7B /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SampleBoostApp_tvOS;
+			productName = SampleBoostApp_tvOS;
+			productReference = 40F4D5481BADB61C367F6550 /* SampleBoostApp_tvOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+		F718A08B98ABEAE682E2B3D2 /* SampleBoostApp_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C91D5EDB3F9A0BAEAB1B02E6 /* Build configuration list for PBXNativeTarget "SampleBoostApp_macOS" */;
+			buildPhases = (
+				A6EA246998563F89B49727F6 /* Sources */,
+				F060B7DC24CDE09D00E79C7B /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SampleBoostApp_macOS;
+			productName = SampleBoostApp_macOS;
+			productReference = 6EC669783594B8F6222C8CF0 /* SampleBoostApp_macOS.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		15BF28E3968A0CF0B1E7016F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				CLASSPREFIX = ABB;
+				LastUpgradeCheck = 1160;
+			};
+			buildConfigurationList = A33C3A92C8F502D4B2D5FA04 /* Build configuration list for PBXProject "SampleBoostApp" */;
+			compatibilityVersion = "Xcode 10.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E06EBEB19BFF627FE92BF365;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A2245B3C427CEDDD5F9E3399 /* SampleBoostApp_iOS */,
+				F718A08B98ABEAE682E2B3D2 /* SampleBoostApp_macOS */,
+				D99702ECD26652F5D824F020 /* SampleBoostApp_tvOS */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3C2652DB1C0A497AABB66829 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F060B7C824CDC7BB00E79C7B /* ABBVegetable.mm in Sources */,
+				F060B76E24CDC47300E79C7B /* main.m in Sources */,
+				F060B76D24CDC47300E79C7B /* AppDelegate.m in Sources */,
+				F060B7D024CDCCD100E79C7B /* SceneDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A278816A9BB85E3890C65F92 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F060B7CA24CDC7BB00E79C7B /* ABBVegetable.mm in Sources */,
+				F060B7BD24CDC60600E79C7B /* main.m in Sources */,
+				F060B7BC24CDC60600E79C7B /* AppDelegate.m in Sources */,
+				F060B7D124CDCCD100E79C7B /* SceneDelegate.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A6EA246998563F89B49727F6 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F060B7C924CDC7BB00E79C7B /* ABBVegetable.mm in Sources */,
+				F060B79424CDC4CA00E79C7B /* AppDelegate.m in Sources */,
+				F060B79324CDC4CA00E79C7B /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		42C1001B525D83FC8ECD3CB1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/Sources/Supporting Files/SampleBoostApp_Catalyst.entitlements";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting Files/Info_iOS.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.faithfracture.SampleBoostApp-iOS";
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		871792D4BB2FD54A738FBA02 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		9330C35FDC32C1CB4A5BDE33 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/Sources/Supporting Files/SampleBoostApp_macOS.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting Files/Info_macOS.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.faithfracture.SampleBoostApp-macOS";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+			};
+			name = Release;
+		};
+		9A52DF4E78749E3B6DC58ED0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_VERSION = 5.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9B092E6B888D47747EB2201E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/Sources/Supporting Files/SampleBoostApp_macOS.entitlements";
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting Files/Info_macOS.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.faithfracture.SampleBoostApp-macOS";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		9D571885E9E6298108E3F849 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "$(SRCROOT)/Sources/Supporting Files/SampleBoostApp_Catalyst.entitlements";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting Files/Info_iOS.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.faithfracture.SampleBoostApp-iOS";
+				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		9F89D8984C9C33BB6A74C059 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting Files/Info_iOS.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.faithfracture.SampleBoostApp-tvOS";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
+			};
+			name = Debug;
+		};
+		F264A7BAA3E423CDD8C1E63B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Supporting Files/Info_iOS.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.faithfracture.SampleBoostApp-tvOS";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3AB80C25D9FBE243AE9EB80D /* Build configuration list for PBXNativeTarget "SampleBoostApp_iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				42C1001B525D83FC8ECD3CB1 /* Debug */,
+				9D571885E9E6298108E3F849 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		A33C3A92C8F502D4B2D5FA04 /* Build configuration list for PBXProject "SampleBoostApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				871792D4BB2FD54A738FBA02 /* Debug */,
+				9A52DF4E78749E3B6DC58ED0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		C91D5EDB3F9A0BAEAB1B02E6 /* Build configuration list for PBXNativeTarget "SampleBoostApp_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9B092E6B888D47747EB2201E /* Debug */,
+				9330C35FDC32C1CB4A5BDE33 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		FE7CEC9B446C56F76F119898 /* Build configuration list for PBXNativeTarget "SampleBoostApp_tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9F89D8984C9C33BB6A74C059 /* Debug */,
+				F264A7BAA3E423CDD8C1E63B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 15BF28E3968A0CF0B1E7016F /* Project object */;
+}

--- a/SampleBoostApp/SampleBoostApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/SampleBoostApp/SampleBoostApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:SampleBoostApp.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/SampleBoostApp/SampleBoostApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SampleBoostApp/SampleBoostApp.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/SampleBoostApp/SampleBoostApp.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/SampleBoostApp/SampleBoostApp.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FILEHEADER</key>
+    <string>
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//</string>
+</dict>
+</plist>

--- a/SampleBoostApp/Sources/Shared/ABBVegetable.h
+++ b/SampleBoostApp/Sources/Shared/ABBVegetable.h
@@ -1,0 +1,18 @@
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ABBVegetable : NSObject
+
+- (void)grow;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SampleBoostApp/Sources/Shared/ABBVegetable.mm
+++ b/SampleBoostApp/Sources/Shared/ABBVegetable.mm
@@ -1,0 +1,63 @@
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import "ABBVegetable.h"
+
+#import <boost/core/swap.hpp>
+
+class CPPVegetable {
+private:
+    int seedsCount;
+    int leavesCount;
+
+public:
+    CPPVegetable() {
+        seedsCount = 12;
+        leavesCount = 4;
+    }
+
+    void grow() {
+        this->logState();
+
+        NSLog(@"Vegetable is growing!");
+        boost::swap(this->seedsCount, this->leavesCount);
+
+        this->logState();
+    }
+
+    void logState() {
+        NSLog(@"Seed count = %d, Leaves count = %d", seedsCount, leavesCount);
+    }
+};
+
+@interface ABBVegetable () {
+@private
+    CPPVegetable *_vegetable;
+}
+
+@end
+
+@implementation ABBVegetable
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _vegetable = new CPPVegetable();
+    }
+    return self;
+}
+
+- (void)dealloc {
+    delete _vegetable;
+}
+
+
+- (void)grow {
+    _vegetable->grow();
+}
+
+@end

--- a/SampleBoostApp/Sources/Supporting Files/Info_iOS.plist
+++ b/SampleBoostApp/Sources/Supporting Files/Info_iOS.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>Launch Screen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/SampleBoostApp/Sources/Supporting Files/Info_macOS.plist
+++ b/SampleBoostApp/Sources/Supporting Files/Info_macOS.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticTermination</key>
+	<true/>
+	<key>NSSupportsSuddenTermination</key>
+	<true/>
+</dict>
+</plist>

--- a/SampleBoostApp/Sources/Supporting Files/SampleBoostApp_Catalyst.entitlements
+++ b/SampleBoostApp/Sources/Supporting Files/SampleBoostApp_Catalyst.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/SampleBoostApp/Sources/Supporting Files/SampleBoostApp_macOS.entitlements
+++ b/SampleBoostApp/Sources/Supporting Files/SampleBoostApp_macOS.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.app-sandbox</key>
+    <true/>
+    <key>com.apple.security.files.user-selected.read-only</key>
+    <true/>
+</dict>
+</plist>

--- a/SampleBoostApp/Sources/iOS/AppDelegate.h
+++ b/SampleBoostApp/Sources/iOS/AppDelegate.h
@@ -1,0 +1,14 @@
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+
+@end
+

--- a/SampleBoostApp/Sources/iOS/AppDelegate.m
+++ b/SampleBoostApp/Sources/iOS/AppDelegate.m
@@ -1,0 +1,35 @@
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import "AppDelegate.h"
+#import "ABBVegetable.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    ABBVegetable *vegetable = [[ABBVegetable alloc] init];
+    [vegetable grow];
+
+    return YES;
+}
+
+
+#pragma mark - UISceneSession lifecycle
+
+
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options {
+    // Called when a new scene session is being created.
+    // Use this method to select a configuration to create the new scene with.
+    return [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+}
+
+@end

--- a/SampleBoostApp/Sources/iOS/Launch Screen.storyboard
+++ b/SampleBoostApp/Sources/iOS/Launch Screen.storyboard
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                                <rect key="frame" x="0.0" y="626.5" width="375" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SampleBoostApp" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="0.0" y="202" width="375" height="43"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="obG-Y5-kRd" secondAttribute="centerX" id="5cz-MP-9tL"/>
+                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="obG-Y5-kRd" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="SfN-ll-jLj"/>
+                            <constraint firstAttribute="bottom" secondItem="obG-Y5-kRd" secondAttribute="bottom" constant="20" id="Y44-ml-fuU"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="20" symbolic="YES" id="x7j-FC-K8j"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/SampleBoostApp/Sources/iOS/SceneDelegate.h
+++ b/SampleBoostApp/Sources/iOS/SceneDelegate.h
@@ -1,0 +1,17 @@
+//
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SceneDelegate : NSObject <UISceneDelegate>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SampleBoostApp/Sources/iOS/SceneDelegate.m
+++ b/SampleBoostApp/Sources/iOS/SceneDelegate.m
@@ -1,0 +1,13 @@
+//
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import "SceneDelegate.h"
+
+@implementation SceneDelegate
+
+@end

--- a/SampleBoostApp/Sources/iOS/main.m
+++ b/SampleBoostApp/Sources/iOS/main.m
@@ -1,0 +1,18 @@
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    NSString * appDelegateClassName;
+    @autoreleasepool {
+        // Setup code that might create autoreleased objects goes here.
+        appDelegateClassName = NSStringFromClass([AppDelegate class]);
+    }
+    return UIApplicationMain(argc, argv, nil, appDelegateClassName);
+}

--- a/SampleBoostApp/Sources/macOS/AppDelegate.h
+++ b/SampleBoostApp/Sources/macOS/AppDelegate.h
@@ -1,0 +1,14 @@
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface AppDelegate : NSObject <NSApplicationDelegate>
+
+
+@end
+

--- a/SampleBoostApp/Sources/macOS/AppDelegate.m
+++ b/SampleBoostApp/Sources/macOS/AppDelegate.m
@@ -1,0 +1,22 @@
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import "AppDelegate.h"
+#import "ABBVegetable.h"
+
+@interface AppDelegate ()
+
+@end
+
+@implementation AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
+    ABBVegetable *vegetable = [[ABBVegetable alloc] init];
+    [vegetable grow];
+}
+
+@end

--- a/SampleBoostApp/Sources/macOS/main.m
+++ b/SampleBoostApp/Sources/macOS/main.m
@@ -1,0 +1,18 @@
+//
+//  SampleBoostApp
+//  https://github.com/faithfracture/Apple-Boost-BuildScript
+//
+//  Distributed under the MIT License.
+//
+
+#import <Cocoa/Cocoa.h>
+#import "AppDelegate.h"
+
+int main(int argc, const char * argv[]) {
+    @autoreleasepool {
+        AppDelegate *appDelegate = [[AppDelegate alloc] init];
+        NSApplication.sharedApplication.delegate = appDelegate;
+        [NSApplication.sharedApplication run];
+    }
+    return NSApplicationMain(argc, argv);
+}

--- a/boost.sh
+++ b/boost.sh
@@ -21,6 +21,8 @@
 #    MIN_TVOS_VERSION: Minimum iOS Target Version (e.g. 11.0)
 #    MACOS_SDK_VERSION: macOS SDK version (e.g. 10.14)
 #    MIN_MACOS_VERSION: Minimum macOS Target Version (e.g. 10.12)
+#    MAC_CATALYST_SDK_VERSION: macOS SDK version when building a Mac Catalyst app (e.g. 10.15)
+#    MIN_MAC_CATALYST_VERSION: Minimum iOS Target Version when building a Mac Catalyst app (e.g. 13.0)
 #
 # If a boost tarball (a file named “boost_$BOOST_VERSION2.tar.bz2”) does not
 # exist in the current directory, this script will attempt to download the
@@ -43,22 +45,14 @@ system test thread timer type_erasure wave"
 BOOTSTRAP_LIBS=""
 
 MIN_IOS_VERSION=11.0
-IOS_SDK_VERSION=$(xcrun --sdk iphoneos --show-sdk-version)
-IOS_SDK_PATH=$(xcrun --sdk iphoneos --show-sdk-path)
-IOSSIM_SDK_PATH=$(xcrun --sdk iphonesimulator --show-sdk-path)
-
 MIN_TVOS_VERSION=11.0
-TVOS_SDK_VERSION=$(xcrun --sdk appletvos --show-sdk-version)
-TVOS_SDK_PATH=$(xcrun --sdk appletvos --show-sdk-path)
-TVOSSIM_SDK_PATH=$(xcrun --sdk appletvsimulator --show-sdk-path)
-
 MIN_MACOS_VERSION=10.12
-MACOS_SDK_VERSION=$(xcrun --sdk macosx --show-sdk-version)
-MACOS_SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
+MIN_MAC_CATALYST_VERSION=13.0
 
 MACOS_ARCHS=("x86_64")
 IOS_ARCHS=("armv7" "arm64")
 IOS_SIM_ARCHS=("i386" "x86_64")
+MAC_CATALYST_ARCHS=("x86_64")
 
 # Applied to all platforms
 CXX_FLAGS=""
@@ -79,6 +73,7 @@ IOS_SIM_DEV_CMD="xcrun --sdk iphonesimulator"
 TVOS_DEV_CMD="xcrun --sdk appletvos"
 TVOS_SIM_DEV_CMD="xcrun --sdk appletvsimulator"
 MACOS_DEV_CMD="xcrun --sdk macosx"
+MAC_CATALYST_DEV_CMD="xcrun --sdk macosx"
 
 BUILD_VARIANT=release
 
@@ -96,6 +91,19 @@ sdkVersion()
 IOS_SDK_VERSION=$(sdkVersion iphoneos)
 TVOS_SDK_VERSION=$(sdkVersion appletvos)
 MACOS_SDK_VERSION=$(sdkVersion macosx)
+MAC_CATALYST_SDK_VERSION=$(sdkVersion macosx)
+
+sdkPath()
+{
+    xcrun --sdk "$1" --show-sdk-path
+}
+
+IOS_SDK_PATH=$(sdkPath iphoneos)
+IOSSIM_SDK_PATH=$(sdkPath iphonesimulator)
+TVOS_SDK_PATH=$(sdkPath appletvos)
+TVOSSIM_SDK_PATH=$(sdkPath appletvsimulator)
+MACOS_SDK_PATH=$(sdkPath macosx)
+MAC_CATALYST_SDK_PATH=$(sdkPath macosx)
 
 usage()
 {
@@ -122,6 +130,9 @@ OPTIONS:
 
     -tvos
         Build for the tvOS platform.
+
+    -mac-catalyst
+        Build for the Mac Catalyst platform (UIKit on Mac).
 
     --boost-version [num]
         Specify which version of Boost to build.
@@ -221,6 +232,18 @@ OPTIONS:
         Specify the macOS architectures to build for. Space-separate list.
         Defaults to ${MACOS_ARCHS[*]}
 
+    --mac-catalyst-sdk [num]
+        Specify the macOS SDK version to build the Mac Catalyst slice with.
+        Defaults to $MAC_CATALYST_SDK_VERSION
+
+    --min-mac-catalyst-version [num]
+        Specify the minimum iOS version to target for the Mac Catalyst slice.
+        Defaults to $MIN_MAC_CATALYST_VERSION
+
+    --macos-archs "(archs, ...)"
+        Specify the Mac Catalyst architectures to build for. Space-separate list.
+        Defaults to ${MAC_CATALYST_ARCHS[*]}
+
     --hidden-visibility
         Compile using -fvisibility=hidden and -fvisibility-inlines-hidden
 
@@ -304,6 +327,10 @@ parseArgs()
 
             -macos)
                 BUILD_MACOS=1
+                ;;
+
+            -mac-catalyst)
+                BUILD_MAC_CATALYST=1
                 ;;
 
             --boost-version)
@@ -396,6 +423,33 @@ parseArgs()
                 fi
                 ;;
 
+            --mac-catalyst-sdk)
+                 if [ -n "$2" ]; then
+                    MAC_CATALYST_SDK_VERSION=$2
+                    shift
+                else
+                    missingParameter "$1"
+                fi
+                ;;
+
+            --min-mac-catalyst-version)
+                if [ -n "$2" ]; then
+                    MIN_MAC_CATALYST_VERSION=$2
+                    shift
+                else
+                    missingParameter "$1"
+                fi
+                ;;
+
+            --mac-catalyst-archs)
+                if [ -n "$2" ]; then
+                    CUSTOM_MAC_CATALYST_ARCHS=$2
+                    shift;
+                else
+                    missingParameter "$1"
+                fi
+                ;;
+
             --hidden-visibility)
                 CXX_FLAGS="$CXX_FLAGS -fvisibility=hidden -fvisibility-inlines-hidden"
                 ;;
@@ -467,6 +521,10 @@ parseArgs()
         read -ra MACOS_ARCHS <<< "${CUSTOM_MACOS_ARCHS[@]}"
     fi
 
+    if [[ "${#CUSTOM_MAC_CATALYST_ARCHS[@]}" -gt 0 ]]; then
+        read -ra MAC_CATALYST_ARCHS <<< "${CUSTOM_MAC_CATALYST_ARCHS[@]}"
+    fi
+
     if [[ "${#CUSTOM_IOS_ARCHS[@]}" -gt 0 ]]; then
         read -ra IOS_ARCHS <<< "${CUSTOM_IOS_ARCHS[@]}"
         IOS_SIM_ARCHS=()
@@ -516,6 +574,10 @@ cleanup()
     if [[ -n $BUILD_MACOS ]]; then
         rm -r "$BOOST_SRC/macos-build"
         rm -r "$MACOS_OUTPUT_DIR"
+    fi
+    if [[ -n $BUILD_MAC_CATALYST ]]; then
+        rm -r "$BOOST_SRC/mac-catalyst-build"
+        rm -r "$MAC_CATALYST_OUTPUT_DIR"
     fi
 
     doneSection
@@ -641,6 +703,15 @@ using darwin : $COMPILER_VERSION~macos
   <cxxflags>"$CXX_FLAGS"
   <linkflags>"$LD_FLAGS"
   <compileflags>"$OTHER_FLAGS ${MACOS_ARCH_FLAGS[*]} $EXTRA_MACOS_FLAGS -isysroot $MACOS_SDK_PATH"
+  <threading>multi
+;
+using darwin : $COMPILER_VERSION~maccatalyst
+: $COMPILER
+: <architecture>x86
+  <target-os>darwin
+  <cxxflags>"$CXX_FLAGS"
+  <linkflags>"$LD_FLAGS"
+  <compileflags>"$OTHER_FLAGS ${MAC_CATALYST_ARCH_FLAGS[*]} $EXTRA_MAC_CATALYST_FLAGS -isysroot $MAC_CATALYST_SDK_PATH -target x86_64-apple-ios$MIN_MAC_CATALYST_VERSION-macabi"
   <threading>multi
 ;
 $USING_MPI
@@ -806,6 +877,37 @@ buildBoost_macOS()
     doneSection
 }
 
+buildBoost_mac_catalyst()
+{
+    cd_or_abort "$BOOST_SRC"
+    mkdir -p "$MAC_CATALYST_OUTPUT_DIR"
+
+    echo Building Boost for Mac Catalyst
+    # Install this one so we can copy the headers for the frameworks...
+    ./b2 "$THREADS" \
+        --build-dir=mac-catalyst-build \
+        --stagedir=mac-catalyst-build/stage \
+        --prefix="$MAC_CATALYST_OUTPUT_DIR/prefix" \
+        toolset="darwin-$COMPILER_VERSION~maccatalyst" \
+        link=static \
+        variant=${BUILD_VARIANT} \
+        stage >> "${MAC_CATALYST_OUTPUT_DIR}/mac-catalyst-build.log" 2>&1
+    # shellcheck disable=SC2181
+    if [ $? != 0 ]; then echo "Error staging Mac Catalyst. Check log."; exit 1; fi
+
+    ./b2 "$THREADS" \
+        --build-dir=mac-catalyst-build \
+        --stagedir=mac-catalyst-build/stage \
+        --prefix="$MAC_CATALYST_OUTPUT_DIR/prefix" \
+        toolset="darwin-$COMPILER_VERSION~maccatalyst" \
+        link=static \
+        variant=${BUILD_VARIANT} \
+        install >> "${MAC_CATALYST_OUTPUT_DIR}/mac-catalyst-build.log" 2>&1
+    # shellcheck disable=SC2181
+    if [ $? != 0 ]; then echo "Error installing Mac Catalyst. Check log."; exit 1; fi
+    doneSection
+}
+
 #===============================================================================
 
 unpackArchive()
@@ -863,6 +965,13 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
         done
     fi
 
+    if [[ -n $BUILD_MAC_CATALYST ]]; then
+        # Mac Catalyst
+        for ARCH in "${MAC_CATALYST_ARCHS[@]}"; do
+            mkdir -p "$MAC_CATALYST_BUILD_DIR/$ARCH/obj"
+        done
+    fi
+
     ALL_LIBS=""
 
     echo Splitting all existing fat binaries...
@@ -915,6 +1024,18 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
                     "$MACOS_BUILD_DIR/${MACOS_ARCHS[0]}/libboost_$NAME.a"
             fi
         fi
+
+        if [[ -n $BUILD_MAC_CATALYST ]]; then
+            if [[ "${#MAC_CATALYST_ARCHS[@]}" -gt 1 ]]; then
+                for ARCH in "${MAC_CATALYST_ARCHS[@]}"; do
+                    $MAC_CATALYST_DEV_CMD lipo "mac-catalyst-build/stage/lib/libboost_$NAME.a" \
+                        -thin "$ARCH" -o "$MAC_CATALYST_BUILD_DIR/$ARCH/libboost_$NAME.a"
+                done
+            else
+                cp "mac-catalyst-build/stage/lib/libboost_$NAME.a" \
+                    "$MAC_CATALYST_BUILD_DIR/${MAC_CATALYST_ARCHS[0]}/libboost_$NAME.a"
+            fi
+        fi
     done
 
     echo "Decomposing each architecture's .a files"
@@ -944,6 +1065,12 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
                 unpackArchive "$MACOS_BUILD_DIR/$ARCH/obj" $NAME
             done
         fi
+
+        if [[ -n $BUILD_MAC_CATALYST ]]; then
+            for ARCH in "${MAC_CATALYST_ARCHS[@]}"; do
+                unpackArchive "$MAC_CATALYST_BUILD_DIR/$ARCH/obj" $NAME
+            done
+        fi
     done
 
     echo "Linking each architecture into an uberlib ($ALL_LIBS => libboost.a )"
@@ -960,6 +1087,11 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
             rm "$MACOS_BUILD_DIR/$ARCH/libboost.a"
         done
     fi
+    if [[ -n $BUILD_MAC_CATALYST ]]; then
+        for ARCH in "${MAC_CATALYST_ARCHS[@]}"; do
+            rm "$MAC_CATALYST_BUILD_DIR/$ARCH/libboost.a"
+        done
+    fi
 
     for NAME in $BOOTSTRAP_LIBS; do
         if [ "$NAME" == "test" ]; then
@@ -967,9 +1099,6 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
         fi
 
         echo "Archiving $NAME"
-
-        # The obj/$NAME/*.o below should all be quoted, but I couldn't figure out how to do that elegantly.
-        # Boost lib names probably won't contain non-word characters any time soon, though. ;) - Jan
 
         if [[ -n $BUILD_IOS ]]; then
             for ARCH in "${IOS_ARCHS[@]}"; do
@@ -994,6 +1123,13 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
             for ARCH in "${MACOS_ARCHS[@]}"; do
                 echo "...macos-$ARCH"
                 (cd_or_abort "$MACOS_BUILD_DIR/$ARCH";  $MACOS_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
+            done
+        fi
+
+        if [[ -n $BUILD_MAC_CATALYST ]]; then
+            for ARCH in "${MAC_CATALYST_ARCHS[@]}"; do
+                echo "...mac-catalyst-$ARCH"
+                (cd_or_abort "$MAC_CATALYST_BUILD_DIR/$ARCH";  $MAC_CATALYST_DEV_CMD ar crus libboost.a "obj/$NAME/"*.o; )
             done
         fi
     done
@@ -1065,6 +1201,25 @@ buildUniversal()
             fi
         done
     fi
+    if [[ -n $BUILD_MAC_CATALYST ]]; then
+        mkdir -p "$MAC_CATALYST_BUILD_DIR/universal"
+
+        cd_or_abort "$MAC_CATALYST_BUILD_DIR"
+        for NAME in $BOOTSTRAP_LIBS; do
+            if [ "$NAME" == "test" ]; then
+                NAME="unit_test_framework"
+            fi
+
+            ARCH_FILES=()
+            for ARCH in "${MAC_CATALYST_ARCHS[@]}"; do
+                ARCH_FILES+=("$ARCH/libboost_$NAME.a")
+            done
+            if [[ "${#ARCH_FILES[@]}" -gt 0 ]]; then
+                echo "... $NAME"
+                $MAC_CATALYST_DEV_CMD lipo -create "${ARCH_FILES[@]}" -o "universal/libboost_$NAME.a" || abort "Lipo $NAME failed"
+            fi
+        done
+    fi
 }
 
 #===============================================================================
@@ -1121,6 +1276,17 @@ buildXCFramework()
             HEADERS_PATH="$INCLUDE_DIR"
         fi
     fi
+    if [[ -n $BUILD_MAC_CATALYST ]]; then
+        for LIBPATH in "$MAC_CATALYST_OUTPUT_DIR"/build/*/libboost.a; do
+            LIB_ARGS+=('-library' "$LIBPATH")
+            SLICES_COUNT=$((SLICES_COUNT + 1))
+        done
+
+        INCLUDE_DIR="$MAC_CATALYST_OUTPUT_DIR/prefix/include"
+        if [ -d "$INCLUDE_DIR" ]; then
+            HEADERS_PATH="$INCLUDE_DIR"
+        fi
+    fi
 
     xcrun xcodebuild -create-xcframework \
         "${LIB_ARGS[@]}" \
@@ -1148,10 +1314,11 @@ buildXCFramework()
 
 parseArgs "$@"
 
-if [[ -z $BUILD_IOS && -z $BUILD_TVOS && -z $BUILD_MACOS ]]; then
+if [[ -z $BUILD_IOS && -z $BUILD_TVOS && -z $BUILD_MACOS && -z $BUILD_MAC_CATALYST ]]; then
     BUILD_IOS=1
     BUILD_TVOS=1
     BUILD_MACOS=1
+    BUILD_MAC_CATALYST=1
 fi
 
 # Must set these after parseArgs to fill in overriden values
@@ -1181,13 +1348,20 @@ OUTPUT_DIR="$CURRENT_DIR/build/boost/$BOOST_VERSION"
 IOS_OUTPUT_DIR="$OUTPUT_DIR/ios/$BUILD_VARIANT"
 TVOS_OUTPUT_DIR="$OUTPUT_DIR/tvos/$BUILD_VARIANT"
 MACOS_OUTPUT_DIR="$OUTPUT_DIR/macos/$BUILD_VARIANT"
+MAC_CATALYST_OUTPUT_DIR="$OUTPUT_DIR/mac-catalyst/$BUILD_VARIANT"
 IOS_BUILD_DIR="$IOS_OUTPUT_DIR/build"
 TVOS_BUILD_DIR="$TVOS_OUTPUT_DIR/build"
 MACOS_BUILD_DIR="$MACOS_OUTPUT_DIR/build"
+MAC_CATALYST_BUILD_DIR="$MAC_CATALYST_OUTPUT_DIR/build"
 
 MACOS_ARCH_FLAGS=()
 for ARCH in "${MACOS_ARCHS[@]}"; do
     MACOS_ARCH_FLAGS+=("-arch $ARCH")
+done
+
+MAC_CATALYST_ARCH_FLAGS=()
+for ARCH in "${MAC_CATALYST_ARCHS[@]}"; do
+    MAC_CATALYST_ARCH_FLAGS+=("-arch $ARCH")
 done
 
 IOS_ARCH_FLAGS=()
@@ -1229,12 +1403,19 @@ printVar "MACOS_SDK_VERSION"
 printVar "MACOS_SDK_PATH"
 printVar "MIN_MACOS_VERSION"
 echo
+printVar "BUILD_MAC_CATALYST" "$(asBool "$BUILD_MAC_CATALYST")"
+printVar "MAC_CATALYST_ARCHS"
+printVar "MAC_CATALYST_SDK_VERSION"
+printVar "MAC_CATALYST_SDK_PATH"
+printVar "MIN_MAC_CATALYST_VERSION"
+echo
 printVar "BOOST_LIBS"
 printVar "BOOST_SRC"
 printVar "XCODE_ROOT"
 printVar "IOS_BUILD_DIR"
 printVar "TVOS_BUILD_DIR"
 printVar "MACOS_BUILD_DIR"
+printVar "MAC_CATALYST_BUILD_DIR"
 printVar "THREADS"
 printVar "BUILD_VARIANT"
 echo
@@ -1261,21 +1442,23 @@ downloadBoost
 unpackBoost
 inventMissingHeaders
 patchBoost
+updateBoost
 
 if [[ -n $BUILD_IOS ]]; then
-    updateBoost "iOS"
     bootstrapBoost "iOS"
     buildBoost_iOS
 fi
 if [[ -n $BUILD_TVOS ]]; then
-    updateBoost "tvOS"
     bootstrapBoost "tvOS"
     buildBoost_tvOS
 fi
 if [[ -n $BUILD_MACOS ]]; then
-    updateBoost "macOS"
     bootstrapBoost "macOS"
     buildBoost_macOS
+fi
+if [[ -n $BUILD_MAC_CATALYST ]]; then
+    bootstrapBoost "iOS"
+    buildBoost_mac_catalyst
 fi
 
 scrunchAllLibsTogetherInOneLibPerPlatform


### PR DESCRIPTION
- Adds a sample project with a target for each supported platform (iOS, tvOS, macOS, and Mac Catalyst) to have CI telling us when boost cannot be built for one of those
  - Adds a gitignore with common xcodeproj ignored files
- Update boost.sh with a new flag `-mac-catalyst` to build for this platform

Fixes #49

I anyone have a Catalyst app this could be tested on that would be great :)

(The sample project built and ran fine on my machine, but it's very minimalistic)