### PR TITLE
Fix macOS $ARCH copying not being used properly

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -910,7 +910,7 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
                 done
             else
                 cp "macos-build/stage/lib/libboost_$NAME.a" \
-                    "$MACOS_BUILD_DIR/$ARCH/libboost_$NAME.a"
+                    "$MACOS_BUILD_DIR/${MACOS_ARCHS[0]}/libboost_$NAME.a"
             fi
         fi
     done


### PR DESCRIPTION
When splitting fat binaries, the wrong variable is used for macOS if there is only 1 arch.