### PR TITLE
Add support for Apple Silicon

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,9 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: maxim-lobanov/setup-xcode@v1.2.1
+      with:
+        xcode-version: latest-stable
     - run: bash boost.sh
     - name: Upload built boost.xcframework
       uses: actions/upload-artifact@v2

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Apple-Boost-BuildScript
-Script for building Boost for Apple platforms (iOS, iOS Simulator, tvOS, tvOS Simulator, OS X)
+Script for building Boost for Apple platforms (iOS, iOS Simulator, tvOS, tvOS Simulator, macOS)
 
 This is a new location for my previous GIST:
     https://gist.github.com/faithfracture/c629ae4c7168216a9856
 
-Builds a Boost framework for iOS, iOS Simulator, tvOS, tvOS Simulator, and macOS.
+Builds a Boost framework for iOS, iOS Simulator, tvOS, tvOS Simulator, and macOS (including Apple Silicon).
 Creates a set of universal libraries that can be used on iOS/tvOS/macOS and in the
 iOS/tvOS simulators. Then creates a pseudo-framework to make using boost in Xcode
 less painful.
@@ -19,6 +19,8 @@ To configure the script, define:
    MIN_TVOS_VERSION:  Minimum tvOS Target Version (e.g. 11.0)
    MACOS_SDK_VERSION:  macOS SDK version (e.g. 10.14)
    MIN_MACOS_VERSION:  Minimum macOS Target Version (e.g. 10.12)
+   MACOS_SILICON_SDK_VERSION: macOS SDK version for Apple Silicon (e.g. 11.0)
+   MIN_MACOS_SILICON_VERSION: Minimum macOS Target Version for Apple Silicon (e.g. 11.0)
 ```
 
 If a boost tarball (a file named “boost_$BOOST_VERSION2.tar.bz2”) does not

--- a/boost.sh
+++ b/boost.sh
@@ -21,7 +21,7 @@
 #    MIN_TVOS_VERSION: Minimum iOS Target Version (e.g. 11.0)
 #    MACOS_SDK_VERSION: macOS SDK version (e.g. 10.14)
 #    MIN_MACOS_VERSION: Minimum macOS Target Version (e.g. 10.12)
-#    MACOS_SILICON_SDK_VERSION: macOS SDK version (e.g. 10.14)
+#    MACOS_SILICON_SDK_VERSION: macOS SDK version for Apple Silicon (e.g. 11.0)
 #    MIN_MACOS_SILICON_VERSION: Minimum macOS Target Version for Apple Silicon (e.g. 11.0)
 #
 # If a boost tarball (a file named “boost_$BOOST_VERSION2.tar.bz2”) does not

--- a/boost.sh
+++ b/boost.sh
@@ -351,6 +351,8 @@ parseArgs()
 
             -macossilicon)
                 BUILD_MACOS_SILICON=1
+                ;;
+
             -mac-catalyst)
                 BUILD_MAC_CATALYST=1
                 ;;
@@ -466,6 +468,11 @@ parseArgs()
             --macos-silicon-archs)
                 if [ -n "$2" ]; then
                     CUSTOM_MACOS_SILICON_ARCHS=$2
+                else
+                    missingParameter "$1"
+                fi
+                ;;
+
             --mac-catalyst-sdk)
                  if [ -n "$2" ]; then
                     MAC_CATALYST_SDK_VERSION=$2
@@ -566,6 +573,8 @@ parseArgs()
 
     if [[ "${#CUSTOM_MACOS_SILICON_ARCHS[@]}" -gt 0 ]]; then
         read -ra MACOS_SILICON_ARCHS <<< "${CUSTOM_MACOS_SILICON_ARCHS[@]}"
+    fi
+
     if [[ "${#CUSTOM_MAC_CATALYST_ARCHS[@]}" -gt 0 ]]; then
         read -ra MAC_CATALYST_ARCHS <<< "${CUSTOM_MAC_CATALYST_ARCHS[@]}"
     fi
@@ -764,6 +773,7 @@ using darwin : $COMPILER_VERSION~macossilicon
   <cxxflags>"$CXX_FLAGS"
   <linkflags>"$LD_FLAGS"
   <compileflags>"$OTHER_FLAGS ${MACOS_SILICON_ARCH_FLAGS[*]} $EXTRA_MACOS_SILICON_FLAGS -isysroot $MACOS_SILICON_SDK_PATH" -target arm64-apple-macos$MIN_MACOS_SILICON_VERSION
+;
 using darwin : $COMPILER_VERSION~maccatalyst
 : $COMPILER
 : <architecture>x86
@@ -1057,6 +1067,7 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
         # macOS Silicon
         for ARCH in "${MACOS_SILICON_ARCHS[@]}"; do
             mkdir -p "$MACOS_SILICON_BUILD_DIR/$ARCH/obj"
+        done
     fi
     if [[ -n $BUILD_MAC_CATALYST ]]; then
         # Mac Catalyst


### PR DESCRIPTION
This PR adds support for Apple Silicon!

<img width="657" alt="Screen Shot 2020-07-30 at 11 02 19 AM" src="https://user-images.githubusercontent.com/5092399/88939095-23ec5c80-d254-11ea-975b-6053e34e8d81.png">

This PR also fixes an issue where the `xcframework` file cannot be made if more than one arch for macOS is used (e.g. i386 with x86_64).

Closes #57