### PR TITLE
Add iOS and tvOS simulator support on arm64 based macs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ## Project-specific
 src/
 build/
+dist/
 *.tar.bz2
 
 # Created by https://www.toptal.com/developers/gitignore/api/xcode,macos

--- a/boost.sh
+++ b/boost.sh
@@ -696,7 +696,7 @@ patchBoost()
 
 #===============================================================================
 
-inventMissingHeaders()
+copyMissingHeaders()
 {
     # These files are missing in the ARM iPhoneOS SDK, but they are in the simulator.
     # They are supported on the device, so we copy them from x86 SDK to a staging area
@@ -710,7 +710,7 @@ inventMissingHeaders()
 
 #===============================================================================
 
-updateBoost()
+updateBoostUserConfigJam()
 {
     echo "Updating boost into $BOOST_SRC..."
 
@@ -1502,7 +1502,7 @@ if [[ -z $BUILD_IOS && -z $BUILD_TVOS && -z $BUILD_MACOS && -z $BUILD_MAC_CATALY
     BUILD_MAC_CATALYST=1
 fi
 
-# Must set these after parseArgs to fill in overriden values
+# Must set these after parseArgs to fill in overridden values
 EXTRA_FLAGS="-fembed-bitcode -Wno-unused-local-typedef -Wno-nullability-completeness"
 
 # The EXTRA_ARM_FLAGS definition works around a thread race issue in
@@ -1635,9 +1635,10 @@ fi
 
 downloadBoost
 unpackBoost
-inventMissingHeaders
+
+copyMissingHeaders
 patchBoost
-updateBoost
+updateBoostUserConfigJam
 
 if [[ -n $BUILD_IOS ]]; then
     bootstrapBoost "iOS"
@@ -1652,7 +1653,6 @@ if [[ -n $BUILD_MACOS ]]; then
     buildBoost_macOS
 fi
 if [[ -n $BUILD_MACOS_SILICON ]]; then
-    updateBoost "macOSSilicon"
     bootstrapBoost "macOSSilicon"
     buildBoost_macOS_silicon
 fi

--- a/boost.sh
+++ b/boost.sh
@@ -33,7 +33,7 @@
 #
 #===============================================================================
 
-BOOST_VERSION=1.73.0
+BOOST_VERSION=1.76.0
 
 BOOST_LIBS="atomic chrono date_time exception filesystem program_options random system thread test"
 ALL_BOOST_LIBS_1_68="atomic chrono container context coroutine coroutine2

--- a/boost.sh
+++ b/boost.sh
@@ -26,7 +26,7 @@
 #    MAC_CATALYST_SDK_VERSION: macOS SDK version when building a Mac Catalyst app (e.g. 10.15)
 #    MIN_MAC_CATALYST_VERSION: Minimum iOS Target Version when building a Mac Catalyst app (e.g. 13.0)
 #
-# If a boost tarball (a file named “boost_$BOOST_VERSION2.tar.bz2”) does not
+# If a boost tarball (a file named “boost_$BOOST_VERSION_SNAKE_CASE.tar.bz2”) does not
 # exist in the current directory, this script will attempt to download the
 # version specified. You may also manually place a matching
 # tarball in the current directory and the script will use that.
@@ -652,9 +652,9 @@ version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; 
 downloadBoost()
 {
     if [ "$(version "$BOOST_VERSION")" -ge "$(version "1.63.0")" ]; then
-        DOWNLOAD_SRC=https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
+        DOWNLOAD_SRC=https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION_SNAKE_CASE}.tar.bz2
     else
-        DOWNLOAD_SRC=http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION2}.tar.bz2/download
+        DOWNLOAD_SRC=http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION_SNAKE_CASE}.tar.bz2/download
     fi
     if [ ! -s "$BOOST_TARBALL" ]; then
         echo "Downloading boost ${BOOST_VERSION} from ${DOWNLOAD_SRC}"
@@ -1140,7 +1140,7 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
                     "$MACOS_SILICON_BUILD_DIR/${MACOS_SILICON_ARCHS[0]}/libboost_$NAME.a"
             fi
         fi
-        
+
         if [[ -n $BUILD_MAC_CATALYST ]]; then
             if [[ "${#MAC_CATALYST_ARCHS[@]}" -gt 1 ]]; then
                 for ARCH in "${MAC_CATALYST_ARCHS[@]}"; do
@@ -1523,9 +1523,9 @@ EXTRA_TVOS_SIM_FLAGS="$EXTRA_FLAGS $EXTRA_ARM_FLAGS -mtvos-simulator-version-min
 EXTRA_MACOS_FLAGS="$EXTRA_FLAGS -mmacosx-version-min=$MIN_MACOS_VERSION"
 EXTRA_MACOS_SILICON_FLAGS="$EXTRA_FLAGS $EXTRA_ARM_FLAGS -mmacosx-version-min=$MIN_MACOS_SILICON_VERSION"
 
-BOOST_VERSION2="${BOOST_VERSION//./_}"
-BOOST_TARBALL="$CURRENT_DIR/boost_$BOOST_VERSION2.tar.bz2"
-BOOST_SRC="$SRCDIR/boost_${BOOST_VERSION2}"
+BOOST_VERSION_SNAKE_CASE="${BOOST_VERSION//./_}"
+BOOST_TARBALL="$CURRENT_DIR/boost_$BOOST_VERSION_SNAKE_CASE.tar.bz2"
+BOOST_SRC="$SRCDIR/boost_${BOOST_VERSION_SNAKE_CASE}"
 OUTPUT_DIR="$CURRENT_DIR/build/boost/$BOOST_VERSION"
 IOS_OUTPUT_DIR="$OUTPUT_DIR/ios/$BUILD_VARIANT"
 TVOS_OUTPUT_DIR="$OUTPUT_DIR/tvos/$BUILD_VARIANT"

--- a/boost.sh
+++ b/boost.sh
@@ -1699,6 +1699,7 @@ if [[ -n "$PURGE" ]]; then
     rm -r boost_*.tar.bz2
     rm -r build
     rm -r src
+    rm -r dist
     echo "Done"
     exit 0
 fi


### PR DESCRIPTION
This PR adds the ability to generate `arm64` slices for both the `iphonesimulator` and `appletvsimulator` sdks. It also fixes an issue that currently exists with the `.xcframework` implementation.

`.xcframeworks` expect to have one folder/slice for each platform it supports, so one slice for `iphoneos`, one for `iphonesimulator`, and so on. The current implementation will break if you attempt to build for iOS with a minimum iOS version of `9.0`: 

```
% ./boost.sh -ios --min-ios-version 9.0

..... Building building building ..... 

Both ios-x86_64-simulator and ios-1386-simulator represent two equivalent library definitions.

... more failures because the xcframework was not built.

Done
================================================
Completed successfully
%
```

The solution is to lipo all of the architectures for a given platform and then use that fat library with the `xcodebuild -create-framework` command.