### PR TITLE
Formatting, spinlock, and 32-bit iOS frameworks

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -1514,7 +1514,8 @@ EXTRA_FLAGS="-fembed-bitcode -Wno-unused-local-typedef -Wno-nullability-complete
 # Note these flags (BOOST_AC_USE_PTHREADS and BOOST_SP_USE_PTHREADS) should
 # only be defined for arm targets. They will cause random (but repeatable)
 # shared_ptr crashes on macOS in boost thread destructors.
-EXTRA_ARM_FLAGS="-DBOOST_AC_USE_PTHREADS -DBOOST_SP_USE_PTHREADS -g -DNDEBUG"
+# Latest incarnation uses SPINLOCK instead as this seems to work better on iOS
+EXTRA_ARM_FLAGS="-DBOOST_SP_USE_SPINLOCK -g -DNDEBUG"
 
 EXTRA_IOS_FLAGS="$EXTRA_FLAGS $EXTRA_ARM_FLAGS -mios-version-min=$MIN_IOS_VERSION"
 EXTRA_IOS_SIM_FLAGS="$EXTRA_FLAGS $EXTRA_ARM_FLAGS -mios-simulator-version-min=$MIN_IOS_VERSION"

--- a/boost.sh
+++ b/boost.sh
@@ -49,7 +49,7 @@ BOOTSTRAP_LIBS=""
 MIN_IOS_VERSION=11.0
 MIN_TVOS_VERSION=11.0
 MIN_MACOS_VERSION=10.12
-MIN_MACOS_SILICON_VERSION=11
+MIN_MACOS_SILICON_VERSION=11.0
 MACOS_SDK_VERSION=$(xcrun --sdk macosx --show-sdk-version)
 MACOS_SDK_PATH=$(xcrun --sdk macosx --show-sdk-path)
 MIN_MAC_CATALYST_VERSION=13.0
@@ -118,13 +118,14 @@ usage()
 {
 cat << EOF
 usage: $0 [{-ios,-tvos,-macos} ...] options
-Build Boost for iOS, iOS Simulator, tvOS, tvOS Simulator, and macOS
+Build Boost for iOS, iOS Simulator, Catalyst, tvOS, tvOS Simulator, macOS, and macOS Silicon
 The -ios, -tvos, and -macOS options may be specified together. Default
 is to build all of them.
 
 Examples:
     ./boost.sh -ios -tvos --boost-version 1.68.0
     ./boost.sh -macos --no-framework
+    ./boost.sh -mac-catalyst -ios --boost-libs "filesystem date_time"
     ./boost.sh --clean
 
 OPTIONS:
@@ -136,6 +137,9 @@ OPTIONS:
 
     -macos
         Build for the macOS platform.
+
+    -macossilicon
+        Build for macOS Apple Silicon platform.
 
     -tvos
         Build for the tvOS platform.
@@ -1072,6 +1076,7 @@ scrunchAllLibsTogetherInOneLibPerPlatform()
             mkdir -p "$MACOS_SILICON_BUILD_DIR/$ARCH/obj"
         done
     fi
+    
     if [[ -n $BUILD_MAC_CATALYST ]]; then
         # Mac Catalyst
         for ARCH in "${MAC_CATALYST_ARCHS[@]}"; do

--- a/changelog
+++ b/changelog
@@ -1,3 +1,13 @@
+-- 2021-03-06 --
+* SPINLOCK fix for iOS
+* Logging formatting fixes
+* Updated usage statement
+* Updated default boost version to 1.75.0
+* Fix for 32/64 bit iOS conflict in XCFramework
+
+-- 2020-12-08 --
+* Added support for Apple Silicon
+
 -- 2020-05-31 --
 * Cleanup build commands and patch of Boost's user-config.jam
 


### PR DESCRIPTION
Turns out iOS has the same issue as macOS, if you are generating 32-bit versions (i.e. supporting prior to 11.0). armv7 and arm64 need to be lipo'd together (as do the simulator versions). Otherwise, you get a similar error message when trying to build the framework. 

In addition, this PR includes:
- The SpinLock fix for iOS thread race fix from issue $50
- Formatting changes I discussed in issue #57
- Some minor log message changes, reflecting concerns/issues I had the first time I used script
- and just for the heck of it, updating to boost 1.75.0 as default

I included an update to the changelog (embarrassingly called "changeling" in commit msg) that reflect these changes and last PR.

If you want me to separate these commits or make any other changes, happy to do so. 

