### PR TITLE
Boost mirror migrated from bintray to jfrog

### DIFF
--- a/boost.sh
+++ b/boost.sh
@@ -652,7 +652,7 @@ version() { echo "$@" | awk -F. '{ printf("%d%03d%03d%03d\n", $1,$2,$3,$4); }'; 
 downloadBoost()
 {
     if [ "$(version "$BOOST_VERSION")" -ge "$(version "1.63.0")" ]; then
-        DOWNLOAD_SRC=https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
+        DOWNLOAD_SRC=https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION2}.tar.bz2
     else
         DOWNLOAD_SRC=http://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION2}.tar.bz2/download
     fi


### PR DESCRIPTION
Attempting to download from the old URL returned an error. The new URL is what you get if you download from boost.org.